### PR TITLE
Enhance Terdex prompt engine and JSON plan parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+build/
+dist/
+.terdex.json
+workspace/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ arrives from the local Ollama runtime. Pass `--chain-of-thought` if you want the
 model to think step-by-step before emitting the final JSON payload (useful for
 more complex tasks).
 
+Browse ready-made chain-of-thought prompt ideas tailored for productivity and
+decision-making workflows:
+
+```bash
+terdex prompts
+```
+
+Output the same list in JSON (useful for scripting or feeding into other tools):
+
+```bash
+terdex prompts --json
+```
+
 Produce machine-readable output instead of the formatted summary and step list:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
 # Terdex
-Terdex
+
+Terdex is a lightweight, localhost-friendly helper designed as a Termux-oriented alternative to cloud-based coding agents. It focuses on reproducible workflows that run entirely on your device, offering simple planning tools and command automation without external dependencies.
+
+## Features
+
+- **Termux-aware planning** – Quickly turn a natural language description into a sequenced plan while highlighting Android/Termux constraints.
+- **Configurable playbooks** – Define repeatable shell command sequences in a `.terdex.json` file and execute them on demand.
+- **Self-hosted and offline** – No remote services are required; the CLI runs locally and is suitable for Termux or any POSIX shell.
+
+## Installation
+
+```bash
+pip install .
+```
+
+To install development dependencies (pytest):
+
+```bash
+pip install .[dev]
+```
+
+To enable Ollama-backed plan generation, install the optional extra after making sure
+that the Ollama service is running and a model (for example, `gemma3`) has been pulled:
+
+```bash
+pip install .[ollama]
+```
+
+## Usage
+
+Initialize Terdex in your project directory:
+
+```bash
+terdex init
+```
+
+Generate a plan for a task:
+
+```bash
+terdex plan "setup sqlite database and migrate data"
+```
+
+Generate a plan using a local Ollama model (falls back to the heuristic planner if the
+model does not return actionable steps). The model is prompted to return structured
+JSON that Terdex converts into the familiar numbered steps:
+
+```bash
+terdex plan --ollama-model gemma3 "optimize python data pipeline"
+```
+
+Add `--stream` to the command to print the model's response incrementally as it
+arrives from the local Ollama runtime. Pass `--chain-of-thought` if you want the
+model to think step-by-step before emitting the final JSON payload (useful for
+more complex tasks).
+
+Run a playbook defined in `.terdex.json`:
+
+```bash
+terdex run bootstrap-termux
+```
+
+Show configuration details and available playbooks:
+
+```bash
+terdex show --playbooks
+```
+
+## Configuration
+
+`terdex init` creates a `.terdex.json` file with defaults:
+
+```json
+{
+  "profile": "default",
+  "workspace": "workspace",
+  "playbooks": {
+    "bootstrap-termux": [
+      "pkg update -y",
+      "pkg install -y git python"
+    ],
+    "run-tests": [
+      "pytest"
+    ]
+  }
+}
+```
+
+Modify playbooks to suit your workflow. Use `--dry-run` when executing to preview commands without running them.
+
+## Development
+
+Run the test suite:
+
+```bash
+pytest
+```
+
+Contributions are welcome! Feel free to open issues or pull requests with improvements or additional Termux playbooks.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terdex is a lightweight, localhost-friendly helper designed as a Termux-oriented
 
 ## Features
 
-- **Termux-aware planning** – Quickly turn a natural language description into a sequenced plan while highlighting Android/Termux constraints.
+- **Termux-aware planning** – Quickly turn a natural language description into a sequenced plan while highlighting Android/Termux constraints and summarizing the requested task.
 - **Configurable playbooks** – Define repeatable shell command sequences in a `.terdex.json` file and execute them on demand.
 - **Self-hosted and offline** – No remote services are required; the CLI runs locally and is suitable for Termux or any POSIX shell.
 
@@ -53,6 +53,12 @@ Add `--stream` to the command to print the model's response incrementally as it
 arrives from the local Ollama runtime. Pass `--chain-of-thought` if you want the
 model to think step-by-step before emitting the final JSON payload (useful for
 more complex tasks).
+
+Produce machine-readable output instead of the formatted summary and step list:
+
+```bash
+terdex plan --json "bootstrap a python project"
+```
 
 Run a playbook defined in `.terdex.json`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "terdex"
+version = "0.1.0"
+description = "Lightweight, offline-friendly coding helper for Termux and local development"
+authors = [{name = "Terdex Maintainers"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+]
+ollama = [
+  "ollama>=0.1.0",
+]
+
+[project.scripts]
+terdex = "terdex.cli:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/terdex/__init__.py
+++ b/terdex/__init__.py
@@ -1,0 +1,5 @@
+"""Terdex package initialization."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/terdex/cli.py
+++ b/terdex/cli.py
@@ -1,0 +1,424 @@
+"""Command line interface for the Terdex assistant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+from .ollama_support import (
+    OllamaUnavailableError,
+    request_plan_from_ollama,
+)
+
+CONFIG_FILE = ".terdex.json"
+DEFAULT_CONFIG = {
+    "profile": "default",
+    "workspace": "workspace",
+    "playbooks": {
+        "bootstrap-termux": [
+            "pkg update -y",
+            "pkg install -y git python"
+        ],
+        "run-tests": [
+            "pytest"
+        ],
+    },
+}
+
+
+@dataclass
+class AppConfig:
+    """Configuration used by Terdex."""
+
+    path: Path
+    profile: str = "default"
+    workspace: Path = Path("workspace")
+    playbooks: Dict[str, List[str]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, directory: Path) -> "AppConfig":
+        config_path = directory / CONFIG_FILE
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"No {CONFIG_FILE} configuration found in {directory}. "
+                "Run `terdex init` first."
+            )
+        data = json.loads(config_path.read_text())
+        workspace = Path(data.get("workspace", DEFAULT_CONFIG["workspace"]))
+        playbooks = {
+            name: list(commands)
+            for name, commands in data.get("playbooks", {}).items()
+        }
+        return cls(
+            path=config_path,
+            profile=data.get("profile", "default"),
+            workspace=workspace,
+            playbooks=playbooks,
+        )
+
+    @classmethod
+    def initialize(cls, directory: Path, overwrite: bool = False) -> "AppConfig":
+        config_path = directory / CONFIG_FILE
+        if config_path.exists() and not overwrite:
+            raise FileExistsError(
+                f"{CONFIG_FILE} already exists. Use --overwrite to replace it."
+            )
+        config_path.write_text(json.dumps(DEFAULT_CONFIG, indent=2))
+        workspace_dir = directory / DEFAULT_CONFIG["workspace"]
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        return cls.load(directory)
+
+    def save(self) -> None:
+        self.path.write_text(
+            json.dumps(
+                {
+                    "profile": self.profile,
+                    "workspace": str(self.workspace),
+                    "playbooks": self.playbooks,
+                },
+                indent=2,
+            )
+        )
+
+
+def detect_termux() -> bool:
+    """Return True if the current environment appears to be Termux."""
+
+    return "TERMUX_VERSION" in os.environ or "com.termux" in os.environ.get("PREFIX", "")
+
+
+def generate_plan(
+    description: str,
+    max_steps: Optional[int] = None,
+    *,
+    ollama_model: Optional[str] = None,
+    stream: bool = False,
+    ollama_chat_fn: Optional[Callable[..., object]] = None,
+    chain_of_thought: bool = False,
+) -> List[str]:
+    """Generate an execution plan from a plain language description."""
+
+    normalized = description.replace("\n", " ").strip()
+    if not normalized:
+        return []
+
+    environment_is_termux = detect_termux()
+    environment_message = _environment_message(environment_is_termux)
+
+    if ollama_model:
+        raw_plan = request_plan_from_ollama(
+            normalized,
+            model=ollama_model,
+            stream=stream,
+            chat_fn=ollama_chat_fn,
+            termux=environment_is_termux,
+            chain_of_thought=chain_of_thought,
+        )
+        steps, ollama_environment = _parse_plan_json(raw_plan)
+        if not steps:
+            steps = _normalize_ollama_output(raw_plan)
+        if not steps:
+            steps = _fallback_steps(normalized)
+        if ollama_environment:
+            environment_message = ollama_environment
+    else:
+        steps = _fallback_steps(normalized)
+
+    if max_steps:
+        steps = steps[:max_steps]
+
+    steps.append(environment_message)
+    return steps
+
+
+def _fallback_steps(normalized_description: str) -> List[str]:
+    sentences = [
+        sentence.strip()
+        for sentence in normalized_description.replace("?", ".")
+        .replace("!", ".")
+        .split(".")
+        if sentence.strip()
+    ]
+
+    plan: List[str] = []
+    for index, sentence in enumerate(sentences, start=1):
+        plan.append(f"Step {index}: {sentence[0].upper() + sentence[1:]}")
+    return plan
+
+
+_LISTING_PREFIX = re.compile(r"^(?:[-*•]\s*|\d+[).:-]\s*|step\s+\d+[:.-]\s*)", re.I)
+
+
+def _parse_plan_json(raw_plan: str) -> tuple[List[str], Optional[str]]:
+    try:
+        payload = json.loads(raw_plan)
+    except json.JSONDecodeError:
+        return [], None
+
+    if not isinstance(payload, dict):
+        return [], None
+
+    environment_text: Optional[str] = None
+    if isinstance(payload.get("environment"), str):
+        env_candidate = payload["environment"].strip()
+        if env_candidate:
+            environment_text = (
+                env_candidate
+                if env_candidate.lower().startswith("environment:")
+                else f"Environment: {env_candidate}"
+            )
+
+    steps_field = payload.get("steps")
+    if not isinstance(steps_field, list):
+        return [], environment_text
+
+    steps: List[str] = []
+    for index, entry in enumerate(steps_field, start=1):
+        title: Optional[str] = None
+        command: Optional[str] = None
+        notes: Optional[str] = None
+
+        if isinstance(entry, dict):
+            raw_title = entry.get("title") or entry.get("summary") or entry.get("action")
+            if isinstance(raw_title, str) and raw_title.strip():
+                title = raw_title.strip()
+            raw_command = entry.get("command")
+            if isinstance(raw_command, str) and raw_command.strip():
+                command = raw_command.strip()
+            raw_notes = entry.get("notes") or entry.get("note")
+            if isinstance(raw_notes, str) and raw_notes.strip():
+                notes = raw_notes.strip()
+        elif isinstance(entry, str) and entry.strip():
+            title = entry.strip()
+
+        fragments = [fragment for fragment in [title, command, notes] if fragment]
+        if not fragments:
+            continue
+        formatted = fragments[0]
+        metadata: List[str] = []
+        if command:
+            metadata.append(f"Command: {command}")
+        if notes:
+            metadata.append(f"Notes: {notes}")
+        if metadata:
+            formatted = f"{formatted}; " + "; ".join(metadata)
+        steps.append(f"Step {index}: {formatted}")
+
+    return steps, environment_text
+
+
+def _normalize_ollama_output(raw_plan: str) -> List[str]:
+    lines: List[str] = []
+    for raw_line in raw_plan.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        stripped = _LISTING_PREFIX.sub("", stripped)
+        if not stripped:
+            continue
+        lines.append(stripped)
+
+    normalized: List[str] = []
+    for index, line in enumerate(lines, start=1):
+        formatted = line[0].upper() + line[1:] if line else line
+        normalized.append(f"Step {index}: {formatted}")
+    return normalized
+
+
+def _environment_message(is_termux: Optional[bool] = None) -> str:
+    if is_termux is None:
+        is_termux = detect_termux()
+    if is_termux:
+        return (
+            "Environment: Detected Termux. Prefer `pkg` for package management and avoid sudo."
+        )
+    return (
+        "Environment: Non-Termux detected. If targeting Termux, ensure commands are `pkg` compatible."
+    )
+
+
+def execute_playbook(commands: Iterable[str], *, shell: bool = True) -> int:
+    """Execute a series of shell commands sequentially."""
+
+    for command in commands:
+        print(f"$ {command}")
+        completed = subprocess.run(command, shell=shell, check=False)
+        if completed.returncode != 0:
+            print(f"Command failed with exit code {completed.returncode}")
+            return completed.returncode
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Terdex – a lightweight, offline-friendly coding helper",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Examples:
+              Initialize configuration:  terdex init
+              Create a plan:            terdex plan "add REST endpoint"
+              Run a playbook:           terdex run bootstrap-termux
+            """
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=Path.cwd(),
+        type=Path,
+        help="Directory that stores the .terdex.json configuration (defaults to CWD).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser(
+        "init", help="Create the default Terdex configuration file"
+    )
+    init_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing configuration if present",
+    )
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="Generate a simple execution plan from a description"
+    )
+    plan_parser.add_argument("description", nargs="*", help="Description to plan")
+    plan_parser.add_argument(
+        "--max-steps", type=int, default=None, help="Limit the number of generated steps"
+    )
+    plan_parser.add_argument(
+        "--ollama-model",
+        dest="ollama_model",
+        default=None,
+        help=(
+            "Use a local Ollama model to draft the plan. Requires the `ollama` package and daemon."
+        ),
+    )
+    plan_parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Stream responses from Ollama when generating plans",
+    )
+    plan_parser.add_argument(
+        "--chain-of-thought",
+        action="store_true",
+        dest="chain_of_thought",
+        help="Ask the model to reason step-by-step before returning the JSON plan",
+    )
+
+    run_parser = subparsers.add_parser(
+        "run", help="Execute a named playbook from the configuration"
+    )
+    run_parser.add_argument("playbook", help="Name of the playbook to execute")
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them",
+    )
+
+    show_parser = subparsers.add_parser(
+        "show", help="Display loaded configuration and environment info"
+    )
+    show_parser.add_argument(
+        "--playbooks",
+        action="store_true",
+        help="Also show available playbooks",
+    )
+
+    return parser
+
+
+def command_init(args: argparse.Namespace) -> int:
+    config_dir = args.config
+    try:
+        config = AppConfig.initialize(config_dir, overwrite=args.overwrite)
+    except FileExistsError as exc:
+        print(exc)
+        return 1
+    print(f"Initialized configuration at {config.path}")
+    print(f"Workspace directory: {config.workspace}")
+    return 0
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    description = " ".join(args.description)
+    try:
+        plan = generate_plan(
+            description,
+            max_steps=args.max_steps,
+            ollama_model=args.ollama_model,
+            stream=args.stream,
+            chain_of_thought=args.chain_of_thought,
+        )
+    except OllamaUnavailableError as exc:
+        print(exc)
+        return 1
+    if not plan:
+        print("No plan generated. Provide a description.")
+        return 1
+    print("Generated plan:\n")
+    for entry in plan:
+        print(f" - {entry}")
+    return 0
+
+
+def command_run(args: argparse.Namespace) -> int:
+    config = AppConfig.load(args.config)
+    if args.playbook not in config.playbooks:
+        print(
+            f"Playbook '{args.playbook}' not found. Available: {', '.join(sorted(config.playbooks)) or 'none'}"
+        )
+        return 1
+    commands = config.playbooks[args.playbook]
+    if args.dry_run:
+        print("Dry run – commands to execute:")
+        for command in commands:
+            print(f" - {command}")
+        return 0
+    return execute_playbook(commands)
+
+
+def command_show(args: argparse.Namespace) -> int:
+    try:
+        config = AppConfig.load(args.config)
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
+
+    environment_lines = [
+        f"Configuration path: {config.path}",
+        f"Profile: {config.profile}",
+        f"Workspace: {config.workspace}",
+        f"Detected Termux: {'yes' if detect_termux() else 'no'}",
+    ]
+    print("\n".join(environment_lines))
+    if args.playbooks:
+        print("\nPlaybooks:")
+        for name, commands in sorted(config.playbooks.items()):
+            print(f" - {name}: {', '.join(commands)}")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    commands = {
+        "init": command_init,
+        "plan": command_plan,
+        "run": command_run,
+        "show": command_show,
+    }
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terdex/cli.py
+++ b/terdex/cli.py
@@ -32,6 +32,19 @@ DEFAULT_CONFIG = {
     },
 }
 
+CHAIN_OF_THOUGHT_PROMPTS = [
+    "Act as a productivity coach. Create a structured, time-blocked schedule for a project manager juggling meetings, deep work, and admin tasks.",
+    "Step by step, outline a project timeline for launching a new product. Include key milestones, potential roadblocks, and solutions.",
+    "Organize this to-do list into high-priority and low-priority tasks.",
+    "Suggest a workflow automation strategy for a marketing team handling multiple campaigns.",
+    "Act as a project manager. Design a simple workflow for handling customer complaints efficiently.",
+    "Analyze this weekly schedule and suggest ways to increase efficiency without compromising work quality.",
+    "Act as a time management expert. Given a workload of 10+ daily tasks, multiple deadlines, and frequent interruptions, suggest a structured prioritization method to ensure high-impact tasks are completed first while minimizing stress and decision fatigue.",
+    "Act as an executive coach. Provide a 5-minute morning reflection exercise to help me set clear priorities and focus on high-impact work.",
+    "Act as a time management expert. I have five urgent tasks, but only time for three. Provide a prioritization framework to decide which to complete first.",
+    "My to-do list keeps growing, and I feel like I'm always behind. Suggest a method to ensure I stay proactive instead of reactive.",
+]
+
 
 @dataclass
 class AppConfig:
@@ -438,6 +451,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also show available playbooks",
     )
 
+    prompts_parser = subparsers.add_parser(
+        "prompts", help="List chain-of-thought prompt ideas for smarter planning"
+    )
+    prompts_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the prompts as JSON for downstream tooling",
+    )
+
     return parser
 
 
@@ -518,6 +540,28 @@ def command_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_prompts(args: argparse.Namespace) -> int:
+    if args.json:
+        payload = {
+            "title": "Chain-of-thought prompts for smarter decision-making",
+            "prompts": CHAIN_OF_THOUGHT_PROMPTS,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    intro = textwrap.dedent(
+        """
+        Chain-of-thought prompt ideas for smarter decision-making and productivity.
+        Use these with `terdex plan --chain-of-thought` to encourage step-by-step reasoning.
+        """
+    ).strip()
+    print(intro)
+    print("")
+    for index, prompt in enumerate(CHAIN_OF_THOUGHT_PROMPTS, start=1):
+        print(f"{index}. {prompt}")
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -527,6 +571,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "plan": command_plan,
         "run": command_run,
         "show": command_show,
+        "prompts": command_prompts,
     }
     return commands[args.command](args)
 

--- a/terdex/engine.py
+++ b/terdex/engine.py
@@ -1,0 +1,76 @@
+"""Prompt engineering utilities for Terdex."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, Optional, Sequence
+
+TERDEX_SYSTEM_PROMPT = """
+You are Terdex, a Termux-aware planning assistant. You help developers working on
+Android devices craft concise, actionable plans that can be executed inside the
+Termux shell. Always consider:
+- Package management relies on `pkg`/`apt` rather than `sudo` or Homebrew.
+- Devices often have limited RAM and CPU resources, so prefer lightweight tools.
+- File paths should avoid hard-coded `/data/data` prefixes and assume a POSIX shell.
+- Networking may be unreliable; cache downloads when possible.
+
+When asked for help you must respond with a single JSON object using the schema:
+{
+  "task_summary": "Short description of the task in 1 sentence",
+  "steps": [
+    {
+      "title": "High-level action title",
+      "command": "Specific Termux-friendly shell command, if relevant",
+      "notes": "Optional clarifications or cautions"
+    }
+  ],
+  "environment": "One sentence reminder about Termux constraints"
+}
+
+If a shell command is not required for a step, use an empty string for the
+"command" field. Keep responses focused and avoid markdown outside the JSON.
+""".strip()
+
+
+@dataclass
+class TerdexEngine:
+    """Utility to generate structured chat prompts for Terdex."""
+
+    enable_chain_of_thought: bool = False
+
+    def build_messages(
+        self,
+        description: str,
+        *,
+        termux: Optional[bool] = None,
+        history: Optional[Sequence[Mapping[str, str]]] = None,
+    ) -> List[Mapping[str, str]]:
+        """Construct a chat message list suitable for the Ollama client."""
+
+        messages: List[Mapping[str, str]] = [{"role": "system", "content": TERDEX_SYSTEM_PROMPT}]
+        if history:
+            for message in history:
+                role = message.get("role")
+                content = message.get("content")
+                if isinstance(role, str) and isinstance(content, str):
+                    messages.append({"role": role, "content": content})
+
+        environment_hint = (
+            "The user is running inside Termux on Android."
+            if termux
+            else "The user may be on a standard Linux distribution but wants Termux-compatible steps."
+        )
+
+        user_instructions = [
+            "Plan the work before execution and output valid JSON only.",
+            environment_hint,
+            f"Task: {description.strip()}",
+        ]
+        if self.enable_chain_of_thought:
+            user_instructions.insert(
+                1,
+                "Think step-by-step to ensure the plan is safe, then provide only the JSON object in the final response.",
+            )
+
+        messages.append({"role": "user", "content": "\n".join(user_instructions)})
+        return messages

--- a/terdex/ollama_support.py
+++ b/terdex/ollama_support.py
@@ -1,0 +1,75 @@
+"""Helpers for interacting with the local Ollama runtime."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from .engine import TerdexEngine
+
+
+class OllamaUnavailableError(RuntimeError):
+    """Raised when the Ollama Python package is not available."""
+
+
+def _load_chat_callable() -> Callable[..., Any]:
+    try:
+        from ollama import chat as ollama_chat  # type: ignore import-not-found
+    except ImportError as exc:  # pragma: no cover - explicit error message
+        raise OllamaUnavailableError(
+            "The `ollama` package is required. Install it with `pip install ollama` "
+            "or `pip install .[ollama]`, and ensure the Ollama service is running."
+        ) from exc
+    return ollama_chat
+
+
+def request_plan_from_ollama(
+    description: str,
+    *,
+    model: str,
+    stream: bool = False,
+    chat_fn: Optional[Callable[..., Any]] = None,
+    termux: Optional[bool] = None,
+    chain_of_thought: bool = False,
+) -> str:
+    """Request a plan from an Ollama model and return the combined text."""
+
+    engine = TerdexEngine(enable_chain_of_thought=chain_of_thought)
+    messages = engine.build_messages(description, termux=termux)
+
+    chat = chat_fn or _load_chat_callable()
+    response = chat(model=model, messages=messages, stream=stream)
+    if stream:
+        chunks: list[str] = []
+        for part in response:  # type: ignore[not-an-iterable]
+            content = _extract_content(part)
+            if content:
+                chunks.append(content)
+        return "".join(chunks)
+    return _extract_content(response)
+
+
+def _extract_content(result: Any) -> str:
+    """Best-effort extraction of the response text from Ollama outputs."""
+
+    if isinstance(result, dict):
+        message = result.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+    message = getattr(result, "message", None)
+    if message is not None:
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            return content
+    if hasattr(result, "__getitem__"):
+        try:
+            message = result["message"]
+            content = message["content"]
+            if isinstance(content, str):
+                return content
+        except Exception:  # pragma: no cover - fall through to default handling
+            pass
+    if isinstance(result, str):
+        return result
+    return ""

--- a/tests/test_cli_prompts.py
+++ b/tests/test_cli_prompts.py
@@ -1,0 +1,23 @@
+import json
+from types import SimpleNamespace
+
+from terdex.cli import CHAIN_OF_THOUGHT_PROMPTS, command_prompts
+
+
+def test_prompts_json_output(capsys):
+    args = SimpleNamespace(json=True)
+    assert command_prompts(args) == 0
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert payload["title"].startswith("Chain-of-thought prompts")
+    assert payload["prompts"] == CHAIN_OF_THOUGHT_PROMPTS
+
+
+def test_prompts_text_output(capsys):
+    args = SimpleNamespace(json=False)
+    assert command_prompts(args) == 0
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured[0].startswith("Chain-of-thought prompt ideas")
+    numbered = [line for line in captured if line and line[0].isdigit()]
+    assert len(numbered) == len(CHAIN_OF_THOUGHT_PROMPTS)
+    assert numbered[0].startswith("1. ")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,18 @@
+from terdex.engine import TERDEX_SYSTEM_PROMPT, TerdexEngine
+
+
+def test_engine_build_messages_includes_context():
+    engine = TerdexEngine()
+    messages = engine.build_messages("set up git", termux=True)
+    assert messages[0]["content"] == TERDEX_SYSTEM_PROMPT
+    assert "Termux" in messages[0]["content"]
+    assert messages[-1]["role"] == "user"
+    assert "set up git" in messages[-1]["content"]
+    assert "Termux" in messages[-1]["content"]
+
+
+def test_engine_chain_of_thought_instruction():
+    engine = TerdexEngine(enable_chain_of_thought=True)
+    messages = engine.build_messages("install python", termux=False)
+    user_content = messages[-1]["content"]
+    assert "Think step-by-step" in user_content

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from terdex.cli import AppConfig, generate_plan
+from terdex.ollama_support import OllamaUnavailableError
+
+
+def test_generate_plan_basic():
+    description = "create api endpoint. add tests. update docs."
+    plan = generate_plan(description)
+    assert plan[0].startswith("Step 1: Create api endpoint")
+    assert any("Environment" in step for step in plan)
+
+
+def test_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    config_dir = tmp_path
+    config = AppConfig.initialize(config_dir)
+    config.profile = "termux"
+    config.playbooks["custom"] = ["echo hello"]
+    config.save()
+
+    loaded = AppConfig.load(config_dir)
+    assert loaded.profile == "termux"
+    assert loaded.playbooks["custom"] == ["echo hello"]
+
+
+def test_detect_termux(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TERMUX_VERSION", "0.118")
+    plan = generate_plan("simple step")
+    assert plan[-1].startswith("Environment: Detected Termux")
+
+    monkeypatch.delenv("TERMUX_VERSION")
+    plan = generate_plan("simple step")
+    assert "Non-Termux" in plan[-1]
+
+
+def test_generate_plan_with_stubbed_ollama():
+    def fake_chat(*, model, messages, stream):
+        assert model == "stub-model"
+        assert not stream
+        assert "do the thing" in messages[-1]["content"]
+        return SimpleNamespace(message=SimpleNamespace(content="1. gather tools\n2. run build"))
+
+    plan = generate_plan(
+        "do the thing",
+        ollama_model="stub-model",
+        ollama_chat_fn=fake_chat,
+    )
+
+    assert plan[0] == "Step 1: Gather tools"
+    assert plan[1] == "Step 2: Run build"
+    assert plan[-1].startswith("Environment:")
+
+
+def test_generate_plan_ollama_missing():
+    with pytest.raises(OllamaUnavailableError):
+        generate_plan("do things", ollama_model="gemma3")
+
+
+def test_generate_plan_with_json_payload():
+    payload = {
+        "task_summary": "Install dependencies",
+        "steps": [
+            {
+                "title": "Update package lists",
+                "command": "pkg update -y",
+                "notes": "Ensure repositories are reachable",
+            },
+            {
+                "title": "Install git",
+                "command": "pkg install -y git",
+                "notes": "",
+            },
+        ],
+        "environment": "Environment: Termux detected"
+    }
+
+    def fake_chat(*, model, messages, stream):
+        assert model == "json-model"
+        assert not stream
+        assert messages[-1]["role"] == "user"
+        return SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))
+
+    plan = generate_plan(
+        "install git",
+        ollama_model="json-model",
+        ollama_chat_fn=fake_chat,
+    )
+
+    assert plan[0].startswith("Step 1: Update package lists")
+    assert "Command: pkg update -y" in plan[0]
+    assert plan[-1] == "Environment: Termux detected"


### PR DESCRIPTION
## Summary
- add a dedicated TerdexEngine module that assembles Termux-aware chat prompts with optional chain-of-thought guidance
- update the Ollama integration and CLI planner to consume JSON responses, surface model-provided environment notes, and expose a chain-of-thought flag
- document the new planning workflow and extend the tests to cover prompt generation and JSON plan parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d657be5048832e9273f84d51a99cbc