### PR TITLE
Add Termux reference command and guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+build/
+dist/
+.terdex.json
+workspace/

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ package management, and Termux:API commands:
 terdex termux
 ```
 
-Request a specific section or machine-readable output:
+Request a specific section—such as the new desktop environment guide—or
+machine-readable output:
 
 ```bash
-terdex termux --section package-management --json
+terdex termux --section desktop --json
 ```
 
 Produce machine-readable output instead of the formatted summary and step list:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,151 @@
 # Terdex
-Terdex
+
+Terdex is a lightweight, localhost-friendly helper designed as a Termux-oriented alternative to cloud-based coding agents. It focuses on reproducible workflows that run entirely on your device, offering simple planning tools and command automation without external dependencies.
+
+## Features
+
+- **Termux-aware planning** – Quickly turn a natural language description into a sequenced plan while highlighting Android/Termux constraints and summarizing the requested task. Successful runs now celebrate with a confetti animation inspired by [t.me/likhonsheikh](https://t.me/likhonsheikh).
+- **Configurable playbooks** – Define repeatable shell command sequences in a `.terdex.json` file and execute them on demand.
+- **Self-hosted and offline** – No remote services are required; the CLI runs locally and is suitable for Termux or any POSIX shell.
+
+## Installation
+
+```bash
+pip install .
+```
+
+Use extras to tailor the installation:
+
+- Development tooling (pytest + Ruff linter):
+
+  ```bash
+  pip install .[dev]
+  ```
+
+- Ollama-backed plan generation (make sure a local model like `gemma3` is ready):
+
+  ```bash
+  pip install .[ollama]
+  ```
+
+- Colorful confetti celebrations powered by `colorama`:
+
+  ```bash
+  pip install .[color]
+  ```
+
+Prefer a single-file installer? Run the helper script:
+
+```bash
+python scripts/install_terdex.py --with-color --with-ollama
+```
+
+## Usage
+
+Initialize Terdex in your project directory:
+
+```bash
+terdex init
+```
+
+Generate a plan for a task:
+
+```bash
+terdex plan "setup sqlite database and migrate data"
+```
+
+Generate a plan using a local Ollama model (falls back to the heuristic planner if the
+model does not return actionable steps). The model is prompted to return structured
+JSON that Terdex converts into the familiar numbered steps:
+
+```bash
+terdex plan --ollama-model gemma3 "optimize python data pipeline"
+```
+
+Add `--stream` to the command to print the model's response incrementally as it
+arrives from the local Ollama runtime. Pass `--chain-of-thought` if you want the
+model to think step-by-step before emitting the final JSON payload (useful for
+more complex tasks).
+
+Browse ready-made chain-of-thought prompt ideas tailored for productivity and
+decision-making workflows:
+
+```bash
+terdex prompts
+```
+
+Output the same list in JSON (useful for scripting or feeding into other tools):
+
+```bash
+terdex prompts --json
+```
+
+Open a Termux quick reference covering keyboard shortcuts, configurable extra keys,
+package management, and Termux:API commands:
+
+```bash
+terdex termux
+```
+
+Request a specific section or machine-readable output:
+
+```bash
+terdex termux --section package-management --json
+```
+
+Produce machine-readable output instead of the formatted summary and step list:
+
+```bash
+terdex plan --json "bootstrap a python project"
+```
+
+Run a playbook defined in `.terdex.json`:
+
+```bash
+terdex run bootstrap-termux --parallel
+```
+
+Show configuration details and available playbooks:
+
+```bash
+terdex show --playbooks
+```
+
+## Documentation and Planning Resources
+
+- `docs/FEATURE_IDEAS.md` lists high-impact roadmap ideas.
+- `docs/TECH_DEBT.md` tracks planner module follow-ups.
+- `docs/CLI_PLAN.md` documents the `terdex plan` endpoint.
+- `docs/MAINTENANCE_STATUS.md` captures dependency health notes.
+
+## Configuration
+
+`terdex init` creates a `.terdex.json` file with defaults:
+
+```json
+{
+  "profile": "default",
+  "workspace": "workspace",
+  "playbooks": {
+    "bootstrap-termux": [
+      "pkg update -y",
+      "pkg install -y git python"
+    ],
+    "run-tests": [
+      "pytest"
+    ]
+  }
+}
+```
+
+Modify playbooks to suit your workflow. Use `--dry-run` when executing to preview commands without running them.
+
+## Development
+
+Run the test suite:
+
+```bash
+pytest
+```
+
+Contributions are welcome! Feel free to open issues or pull requests with improvements or additional Termux playbooks.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Prefer a single-file installer? Run the helper script:
 python scripts/install_terdex.py --with-color --with-ollama
 ```
 
+Need a shell-friendly wrapper? Use the executable installer instead:
+
+```bash
+scripts/installer.sh --with-color --with-ollama
+```
+
 ## Usage
 
 Initialize Terdex in your project directory:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ JSON that Terdex converts into the familiar numbered steps:
 terdex plan --ollama-model gemma3 "optimize python data pipeline"
 ```
 
+Remote providers are supported as well. Configure an API key through an environment
+variable and request a free developer model from OpenRouter (or another
+OpenAI-compatible endpoint):
+
+```bash
+export OPENROUTER_API_KEY=your-token
+terdex plan --provider openrouter --model meta/llama-3.1-8b-instruct \
+  --api-key-env OPENROUTER_API_KEY "summarize the onboarding docs"
+```
+
+Pass `--api-base` to target hosted alternatives or Hugging Face Inference, and use
+`--option key=value` for provider-specific flags. Gemini and Cohere adapters are
+available with their respective API keys via `--provider gemini` or `--provider cohere`.
+
 Add `--stream` to the command to print the model's response incrementally as it
 arrives from the local Ollama runtime. Pass `--chain-of-thought` if you want the
 model to think step-by-step before emitting the final JSON payload (useful for
@@ -141,11 +155,18 @@ terdex show --playbooks
     "run-tests": [
       "pytest"
     ]
+  },
+  "llm": {
+    "provider": "heuristic",
+    "model": "",
+    "api_base": "",
+    "api_key_env": "",
+    "options": {}
   }
 }
 ```
 
-Modify playbooks to suit your workflow. Use `--dry-run` when executing to preview commands without running them.
+Modify playbooks to suit your workflow. Use `--dry-run` when executing to preview commands without running them. Update the `llm` section to set the default provider (e.g. `ollama`, `openrouter`, `gemini`, `cohere`, or `huggingface`) and supply an environment variable for API keys so secrets never touch disk.
 
 ## Development
 

--- a/docs/CLI_PLAN.md
+++ b/docs/CLI_PLAN.md
@@ -7,16 +7,25 @@ terdex plan [OPTIONS] "TASK DESCRIPTION"
 ## Description
 
 Generates a Termux-aware execution plan for the provided task description. When
-an Ollama model is configured, the command requests structured JSON and falls
-back to heuristics if the model response is unusable.
+a language model provider (Ollama, OpenRouter, Gemini, Cohere, Hugging Face,
+etc.) is configured, the command requests structured JSON and falls back to
+heuristics if the model response is unusable.
 
 ## Options
 
 - `--max-steps INTEGER` – Limit the number of displayed plan steps.
-- `--ollama-model TEXT` – Name of the local Ollama model to query.
+- `--provider [heuristic|ollama|openrouter|gemini|cohere|huggingface]` –
+  Provider to use when contacting a model API.
+- `--model TEXT` – Model identifier for the selected provider.
+- `--ollama-model TEXT` – Backwards compatible alias for choosing an Ollama
+  model.
 - `--stream` – Stream Ollama responses as they are generated.
 - `--chain-of-thought` – Ask the model to reason step-by-step before returning
   the final JSON payload.
+- `--api-base TEXT` – Override the provider API base URL.
+- `--api-key TEXT` – Explicit API key (use env vars when possible).
+- `--api-key-env TEXT` – Environment variable containing the API key.
+- `--option key=value` – Additional provider-specific options (repeatable).
 - `--json` – Output the machine-readable representation instead of formatted
   text.
 

--- a/docs/CLI_PLAN.md
+++ b/docs/CLI_PLAN.md
@@ -1,0 +1,31 @@
+# `terdex plan` Endpoint
+
+```
+terdex plan [OPTIONS] "TASK DESCRIPTION"
+```
+
+## Description
+
+Generates a Termux-aware execution plan for the provided task description. When
+an Ollama model is configured, the command requests structured JSON and falls
+back to heuristics if the model response is unusable.
+
+## Options
+
+- `--max-steps INTEGER` – Limit the number of displayed plan steps.
+- `--ollama-model TEXT` – Name of the local Ollama model to query.
+- `--stream` – Stream Ollama responses as they are generated.
+- `--chain-of-thought` – Ask the model to reason step-by-step before returning
+  the final JSON payload.
+- `--json` – Output the machine-readable representation instead of formatted
+  text.
+
+## Output
+
+- **Summary** – Single sentence describing the task.
+- **Steps** – Numbered actions with optional command and notes sections.
+- **Environment** – Reminder tailored to Termux or general POSIX systems.
+
+On success the CLI emits a celebratory confetti animation acknowledging
+`t.me/likhonsheikh` for the inspiration.
+

--- a/docs/FEATURE_IDEAS.md
+++ b/docs/FEATURE_IDEAS.md
@@ -1,0 +1,11 @@
+# Terdex Feature Ideas
+
+1. **Interactive Chat Mode** – Layer a lightweight REPL on top of the planner so
+   users can iteratively refine steps, accept or reject actions, and request
+   clarifications without re-running the full command.
+2. **Playbook Marketplace** – Provide a curated catalog of Termux-ready
+   playbooks contributed by the community, installable via a single command.
+3. **Workspace Health Checks** – Add a `terdex doctor` command that inspects the
+   local environment for missing packages, stale caches, or risky settings and
+   produces remediation steps tailored for Termux devices.
+

--- a/docs/MAINTENANCE_STATUS.md
+++ b/docs/MAINTENANCE_STATUS.md
@@ -1,0 +1,11 @@
+# Dependency Maintenance Snapshot
+
+| Package   | Observed Version | Notes |
+|-----------|-----------------|-------|
+| colorama  | n/a             | Install via `pip install colorama` to enable confetti output. Widely used across Python CLIs and regularly updated. |
+| ollama    | >=0.1.0         | Optional dependency for local LLM support. Active development on GitHub with frequent releases. |
+| pytest    | >=7.0           | Industry-standard testing framework with ongoing maintenance and long-term support. |
+
+> The snapshot is based on publicly documented release activity as of 2024. Run
+> `pip index versions <package>` for the most up-to-date information.
+

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,14 @@
+# Terdex Technical Debt
+
+## `terdex/planner.py`
+
+- **Mixed responsibilities**: The planner still performs JSON parsing and
+  heuristic fallback logic in a single module. Extracting dedicated serializers
+  would make it easier to plug in additional model providers.
+- **Sparse validation**: Parsed plans accept any string, leaving room for
+  malformed output when models hallucinate fields. Introducing pydantic or a
+  schema validation layer would harden the interface.
+- **Limited localization**: Messages returned from `_environment_message` and
+  `_derive_summary` are English-only. Hooking in translation tables would unlock
+  multi-language support for the CLI.
+

--- a/docs/TERMUX_GUIDE.md
+++ b/docs/TERMUX_GUIDE.md
@@ -1,0 +1,69 @@
+# Termux Quick Reference
+
+Terdex ships with a built-in `terdex termux` command that summarises the
+everyday shortcuts and configuration tweaks needed to stay productive on a
+touch-first Android device. This guide mirrors that reference in a markdown
+format so you can browse it offline or extend it for local documentation.
+
+## Keyboard Shortcuts
+
+- Volume down doubles as **Ctrl**, allowing classic shortcuts:
+  - `Ctrl+A` / `Ctrl+E` move to the start or end of the line.
+  - `Ctrl+K` / `Ctrl+U` delete to the end or start of the line.
+  - `Ctrl+L` clears the terminal.
+  - `Ctrl+C` stops the current process, `Ctrl+Z` suspends it, and `Ctrl+D` sends EOF.
+- Volume up acts as an alternate modifier:
+  - `Volume Up+E` emits **Esc** and `Volume Up+T` emits **Tab**.
+  - `Volume Up+1` through `Volume Up+0` provide function keys **F1–F10**.
+  - Arrow keys are available via `Volume Up+A/D/W/S`.
+
+## Extra Keys Configuration
+
+Customise the additional keys row by editing `~/.termux/termux.properties`:
+
+- `extra-keys-style = default` switches between presets such as `default`,
+  `arrows-only`, and `all`.
+- `extra-keys = [['ESC','/','-','HOME','UP','END','PGUP'], ['TAB','CTRL','ALT','LEFT','DOWN','RIGHT','PGDN']]`
+  defines multi-row layouts.
+- Pop-up macros allow swipe gestures, e.g.
+  `{key: ESC, popup: {macro: "CTRL d", display: "exit"}}`.
+- Run `termux-reload-settings` after editing to apply changes immediately.
+
+## Package Management Basics
+
+Termux wraps `apt` with the `pkg` helper; stick to this toolchain to avoid
+permission issues:
+
+- `pkg install <package>` installs new software (and triggers an `apt update` when needed).
+- `pkg upgrade` refreshes every installed package; run it regularly.
+- `pkg uninstall <package>` removes software while keeping configuration files.
+- Clean caches with `pkg autoclean` (outdated archives) or `pkg clean` (all caches).
+- Explore repositories through `pkg list-all`, search with `pkg search <query>`,
+  and enable optional collections via packages like `science-repo` or `x11-repo`.
+
+## Termux API Essentials
+
+Install the Termux:API Android add-on and the `termux-api` package to script device
+hardware safely. Popular commands include:
+
+- `termux-battery-status` for battery metrics.
+- `termux-clipboard-get` / `termux-clipboard-set` to bridge the clipboard.
+- `termux-notification` for rich Android notifications.
+- `termux-toast` to display quick toasts.
+- `termux-camera-photo` to capture images directly to a file.
+- `termux-location` for coarse or fine location data.
+- `termux-media-player` to play audio or video.
+
+## Appearance and Session Tweaks
+
+Additional options inside `~/.termux/termux.properties` help tailor the UI:
+
+- `use-black-ui=true` forces dark drawers and dialogs.
+- `fullscreen=true` maximises the terminal (combine with
+  `use-fullscreen-workaround=true` on devices that hide the extra keys row).
+- `shortcut.create-session=ctrl + t` opens a new terminal session via `Volume Down+T`.
+- `shortcut.next-session` / `shortcut.previous-session` bind navigation between panes.
+- `enforce-char-based-input=true` works around keyboards that inject words instead of characters.
+- `terminal-margin-horizontal=6` adjusts horizontal padding to avoid clipped edges.
+
+Consult the official [Termux Wiki](https://wiki.termux.com/) for deeper dives.

--- a/docs/TERMUX_GUIDE.md
+++ b/docs/TERMUX_GUIDE.md
@@ -66,4 +66,36 @@ Additional options inside `~/.termux/termux.properties` help tailor the UI:
 - `enforce-char-based-input=true` works around keyboards that inject words instead of characters.
 - `terminal-margin-horizontal=6` adjusts horizontal padding to avoid clipped edges.
 
+## Desktop Environments
+
+Run full graphical desktops through a local VNC server. Keep `~/.vnc/xstartup`
+minimal—just the command that launches the desktop session—and manage the rest
+via each environment's autostart hooks.
+
+- **XFCE:** `pkg install xfce4` then populate `~/.vnc/xstartup` with
+  `#!/data/data/com.termux/files/usr/bin/sh` and `xfce4-session &`.
+  Add tools like `netsurf` or `xfce4-terminal` for a friendlier desktop.
+- **LXQt:** Install with `pkg install lxqt` and configure
+  `startlxqt &` in the xstartup file. Pair with `otter-browser` and `qterminal`.
+- **MATE:** Install `pkg install mate-* marco` and start the session with
+  `mate-session &`. Bring in `netsurf` or `mate-terminal` as needed.
+- **Openbox:** Launch using `openbox-session &` in `~/.vnc/xstartup` and manage
+  panels or wallpaper via `${PREFIX}/etc/xdg/openbox/autostart`
+  (e.g. launching `pypanel` or setting the background).
+
+## Termux X11 Packages
+
+The community-maintained X11 repository unlocks additional desktop packages.
+
+- Enable the repository with `pkg install x11-repo` (Android 7+).
+- Use `pkg install tigervnc` and connect with your favourite VNC viewer to see
+  graphical output.
+- Keep `~/.vnc/xstartup` trimmed to just the session launch command to avoid
+  conflicting daemons.
+- Build or customise packages by cloning
+  `https://github.com/termux/x11-packages`, running `./start-builder.sh`, and
+  executing `./build-package.sh -a <arch> <package>`.
+- Note that hardware acceleration is typically unavailable within these VNC
+  environments, so expect software rendering.
+
 Consult the official [Termux Wiki](https://wiki.termux.com/) for deeper dives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[project]
+name = "terdex"
+version = "0.1.0"
+description = "Lightweight, offline-friendly coding helper for Termux and local development"
+authors = [{name = "Terdex Maintainers"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+  "ruff>=0.5.5",
+]
+color = [
+  "colorama>=0.4.6",
+]
+ollama = [
+  "ollama>=0.1.0",
+]
+
+[project.scripts]
+terdex = "terdex.cli:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = ["E203"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/scripts/install_terdex.py
+++ b/scripts/install_terdex.py
@@ -1,0 +1,47 @@
+"""Single-file installer for the Terdex CLI."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def install(package_path: Path, *, extras: list[str]) -> int:
+    base = str(package_path)
+    if extras:
+        extra_str = ",".join(extras)
+        base = f"{base}[{extra_str}]"
+    cmd = [sys.executable, "-m", "pip", "install", base]
+    print(f"Running: {' '.join(cmd)}")
+    return subprocess.call(cmd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Install the Terdex CLI")
+    parser.add_argument(
+        "--with-ollama",
+        action="store_true",
+        help="Install the Ollama integration extras",
+    )
+    parser.add_argument(
+        "--with-color",
+        action="store_true",
+        help="Install colorized confetti support via colorama",
+    )
+    args = parser.parse_args(argv)
+
+    extras: list[str] = []
+    if args.with_ollama:
+        extras.append("ollama")
+    if args.with_color:
+        extras.append("color")
+
+    package_path = Path(__file__).resolve().parent.parent
+    return install(package_path, extras=extras)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+PYTHON=${PYTHON:-python3}
+
+WITH_OLLAMA=0
+WITH_COLOR=0
+PASS_ARGS=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --with-ollama)
+      WITH_OLLAMA=1
+      ;;
+    --with-color)
+      WITH_COLOR=1
+      ;;
+    --python)
+      if [ "$#" -lt 2 ]; then
+        echo "--python requires an interpreter path" >&2
+        exit 1
+      fi
+      PYTHON="$2"
+      shift
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: installer.sh [options]
+
+Options:
+  --with-ollama   Install the Ollama extra
+  --with-color    Install the colorized confetti extra
+  --python PATH   Use a specific Python interpreter
+  -h, --help      Show this message
+
+Any additional arguments are forwarded to the underlying Python installer.
+USAGE
+      exit 0
+      ;;
+    --)
+      shift
+      PASS_ARGS="$PASS_ARGS $*"
+      break
+      ;;
+    *)
+      PASS_ARGS="$PASS_ARGS $1"
+      ;;
+  esac
+  shift
+done
+
+EXTRA_FLAGS=""
+if [ "$WITH_OLLAMA" -eq 1 ]; then
+  EXTRA_FLAGS="$EXTRA_FLAGS --with-ollama"
+fi
+if [ "$WITH_COLOR" -eq 1 ]; then
+  EXTRA_FLAGS="$EXTRA_FLAGS --with-color"
+fi
+
+set -x
+"$PYTHON" "$SCRIPT_DIR/install_terdex.py" $EXTRA_FLAGS $PASS_ARGS

--- a/terdex/__init__.py
+++ b/terdex/__init__.py
@@ -1,0 +1,5 @@
+"""Terdex package initialization."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/terdex/cli.py
+++ b/terdex/cli.py
@@ -1,0 +1,339 @@
+"""Command line interface for the Terdex assistant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import textwrap
+from pathlib import Path
+from typing import List, Optional
+
+from .config import AppConfig, detect_termux
+from .ollama_support import OllamaUnavailableError
+from .planner import Plan, PlanStep, generate_plan
+from .playbooks import execute_playbook
+from .plugins.confetti import celebrate_success
+from .termux_reference import TERMUX_REFERENCE, lookup_section
+
+__all__ = [
+    "AppConfig",
+    "Plan",
+    "PlanStep",
+    "generate_plan",
+    "build_parser",
+    "command_init",
+    "command_plan",
+    "command_run",
+    "command_show",
+    "command_prompts",
+    "command_termux",
+    "main",
+]
+
+CHAIN_OF_THOUGHT_PROMPTS = [
+    (
+        "Act as a productivity coach. Create a structured, time-blocked schedule for "
+        "a project manager juggling meetings, deep work, and admin tasks."
+    ),
+    (
+        "Step by step, outline a project timeline for launching a new product. Include "
+        "key milestones, potential roadblocks, and solutions."
+    ),
+    "Organize this to-do list into high-priority and low-priority tasks.",
+    (
+        "Suggest a workflow automation strategy for a marketing team handling "
+        "multiple campaigns."
+    ),
+    (
+        "Act as a project manager. Design a simple workflow for handling customer "
+        "complaints efficiently."
+    ),
+    (
+        "Analyze this weekly schedule and suggest ways to increase efficiency without "
+        "compromising work quality."
+    ),
+    (
+        "Act as a time management expert. Given a workload of 10+ daily tasks, multiple "
+        "deadlines, and frequent interruptions, suggest a structured prioritization "
+        "method to ensure high-impact tasks are completed first while minimizing "
+        "stress and decision fatigue."
+    ),
+    (
+        "Act as an executive coach. Provide a 5-minute morning reflection exercise to "
+        "help me set clear priorities and focus on high-impact work."
+    ),
+    (
+        "Act as a time management expert. I have five urgent tasks, but only time for "
+        "three. Provide a prioritization framework to decide which to complete first."
+    ),
+    (
+        "My to-do list keeps growing, and I feel like I'm always behind. Suggest a "
+        "method to ensure I stay proactive instead of reactive."
+    ),
+]
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Terdex – a lightweight, offline-friendly coding helper",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Examples:
+              Initialize configuration:  terdex init
+              Create a plan:            terdex plan "add REST endpoint"
+              Run a playbook:           terdex run bootstrap-termux
+            """
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=Path.cwd(),
+        type=Path,
+        help="Directory that stores the .terdex.json configuration (defaults to CWD).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser(
+        "init", help="Create the default Terdex configuration file"
+    )
+    init_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing configuration if present",
+    )
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="Generate a simple execution plan from a description"
+    )
+    plan_parser.add_argument("description", nargs="*", help="Description to plan")
+    plan_parser.add_argument(
+        "--max-steps", type=int, default=None, help="Limit the number of generated steps"
+    )
+    plan_parser.add_argument(
+        "--ollama-model",
+        dest="ollama_model",
+        default=None,
+        help=(
+            "Use a local Ollama model to draft the plan. Requires the `ollama` package and daemon."
+        ),
+    )
+    plan_parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Stream responses from Ollama when generating plans",
+    )
+    plan_parser.add_argument(
+        "--chain-of-thought",
+        action="store_true",
+        dest="chain_of_thought",
+        help="Ask the model to reason step-by-step before returning the JSON plan",
+    )
+    plan_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the generated plan as JSON instead of human-readable text",
+    )
+
+    run_parser = subparsers.add_parser(
+        "run", help="Execute a named playbook from the configuration"
+    )
+    run_parser.add_argument("playbook", help="Name of the playbook to execute")
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them",
+    )
+    run_parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run playbook commands using a thread pool for independent tasks",
+    )
+
+    show_parser = subparsers.add_parser(
+        "show", help="Display loaded configuration and environment info"
+    )
+    show_parser.add_argument(
+        "--playbooks",
+        action="store_true",
+        help="Also show available playbooks",
+    )
+
+    prompts_parser = subparsers.add_parser(
+        "prompts", help="List chain-of-thought prompt ideas for smarter planning"
+    )
+    prompts_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the prompts as JSON for downstream tooling",
+    )
+
+    termux_parser = subparsers.add_parser(
+        "termux",
+        help="Show curated Termux shortcuts, configuration tips, and API commands",
+    )
+    termux_parser.add_argument(
+        "--section",
+        help="Limit output to a specific section key (e.g. keyboard, package-management)",
+    )
+    termux_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the Termux reference guide as JSON",
+    )
+
+    return parser
+
+
+def command_init(args: argparse.Namespace) -> int:
+    config_dir = args.config
+    try:
+        config = AppConfig.initialize(config_dir, overwrite=args.overwrite)
+    except FileExistsError as exc:
+        print(exc)
+        return 1
+    print(f"Initialized configuration at {config.path}")
+    print(f"Workspace directory: {config.workspace}")
+    return 0
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    description = " ".join(args.description)
+    try:
+        plan = generate_plan(
+            description,
+            max_steps=args.max_steps,
+            ollama_model=args.ollama_model,
+            stream=args.stream,
+            chain_of_thought=args.chain_of_thought,
+        )
+    except OllamaUnavailableError as exc:
+        print(exc)
+        return 1
+    if plan.is_empty():
+        print("No plan generated. Provide a description.")
+        return 1
+    if args.json:
+        print(json.dumps(plan.to_dict(), indent=2))
+        return 0
+
+    print("Generated plan:\n")
+    if plan.summary:
+        print(f"Summary: {plan.summary}\n")
+    for line in plan.formatted_output():
+        print(line)
+    celebrate_success("Plan ready to execute!")
+    return 0
+
+
+def command_run(args: argparse.Namespace) -> int:
+    config = AppConfig.load(args.config)
+    if args.playbook not in config.playbooks:
+        available = ", ".join(sorted(config.playbooks)) or "none"
+        print(f"Playbook '{args.playbook}' not found. Available: {available}")
+        return 1
+    commands = config.playbooks[args.playbook]
+    if args.dry_run:
+        print("Dry run – commands to execute:")
+        for command in commands:
+            print(f" - {command}")
+        return 0
+    exit_code = execute_playbook(
+        commands,
+        parallel=args.parallel,
+    )
+    if exit_code == 0:
+        celebrate_success("Playbook completed successfully!")
+    return exit_code
+
+
+def command_show(args: argparse.Namespace) -> int:
+    try:
+        config = AppConfig.load(args.config)
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
+
+    environment_lines = [
+        f"Configuration path: {config.path}",
+        f"Profile: {config.profile}",
+        f"Workspace: {config.workspace}",
+        f"Detected Termux: {'yes' if detect_termux() else 'no'}",
+    ]
+    print("\n".join(environment_lines))
+    if args.playbooks:
+        print("\nPlaybooks:")
+        for name, commands in sorted(config.playbooks.items()):
+            print(f" - {name}: {', '.join(commands)}")
+    return 0
+
+
+def command_prompts(args: argparse.Namespace) -> int:
+    if args.json:
+        payload = {
+            "title": "Chain-of-thought prompts for smarter decision-making",
+            "prompts": CHAIN_OF_THOUGHT_PROMPTS,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    intro = textwrap.dedent(
+        """
+        Chain-of-thought prompt ideas for smarter decision-making and productivity.
+        Use these with `terdex plan --chain-of-thought` to encourage step-by-step reasoning.
+        """
+    ).strip()
+    print(intro)
+    print("")
+    for index, prompt in enumerate(CHAIN_OF_THOUGHT_PROMPTS, start=1):
+        print(f"{index}. {prompt}")
+    return 0
+
+
+def command_termux(args: argparse.Namespace) -> int:
+    if args.section:
+        section = lookup_section(args.section)
+        if section is None:
+            available = ", ".join(section.key for section in TERMUX_REFERENCE)
+            print(f"Unknown section '{args.section}'. Available: {available}")
+            return 1
+        sections = [section]
+    else:
+        sections = TERMUX_REFERENCE
+
+    if args.json:
+        payload = {
+            "title": "Termux quick reference",
+            "sections": [section.to_dict() for section in sections],
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    for index, section in enumerate(sections):
+        if index:
+            print("")
+        print(section.title)
+        print("=" * len(section.title))
+        print(section.summary)
+        print("")
+        for entry in section.entries:
+            print(f"- {entry.name}: {entry.description}")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    commands = {
+        "init": command_init,
+        "plan": command_plan,
+        "run": command_run,
+        "show": command_show,
+        "prompts": command_prompts,
+        "termux": command_termux,
+    }
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terdex/config.py
+++ b/terdex/config.py
@@ -1,0 +1,122 @@
+"""Configuration helpers for the Terdex CLI.
+
+This module centralizes configuration loading and environment detection so the
+command handlers can focus on orchestration. The functions include
+Sphinx-style docstrings to support automatic API documentation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+CONFIG_FILE = ".terdex.json"
+DEFAULT_CONFIG = {
+    "profile": "default",
+    "workspace": "workspace",
+    "playbooks": {
+        "bootstrap-termux": [
+            "pkg update -y",
+            "pkg install -y git python",
+        ],
+        "run-tests": [
+            "pytest",
+        ],
+    },
+}
+
+
+@dataclass
+class AppConfig:
+    """Persisted settings for Terdex.
+
+    :param path: Absolute path to the configuration file backing the instance.
+    :param profile: Active profile name for display purposes.
+    :param workspace: Directory path used for per-project workspaces.
+    :param playbooks: Mapping of playbook names to ordered shell commands.
+    """
+
+    path: Path
+    profile: str = "default"
+    workspace: Path = Path("workspace")
+    playbooks: Dict[str, List[str]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, directory: Path) -> "AppConfig":
+        """Return an :class:`AppConfig` from ``directory``.
+
+        :param directory: Target directory that should contain ``.terdex.json``.
+        :raises FileNotFoundError: If the configuration file is missing.
+        :return: Parsed configuration data.
+        """
+
+        config_path = directory / CONFIG_FILE
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"No {CONFIG_FILE} configuration found in {directory}. "
+                "Run `terdex init` first."
+            )
+        data = json.loads(config_path.read_text())
+        workspace = Path(data.get("workspace", DEFAULT_CONFIG["workspace"]))
+        playbooks = {
+            name: list(commands)
+            for name, commands in data.get("playbooks", {}).items()
+        }
+        return cls(
+            path=config_path,
+            profile=data.get("profile", "default"),
+            workspace=workspace,
+            playbooks=playbooks,
+        )
+
+    @classmethod
+    def initialize(cls, directory: Path, overwrite: bool = False) -> "AppConfig":
+        """Create a default configuration in ``directory``.
+
+        :param directory: Destination directory for ``.terdex.json``.
+        :param overwrite: Whether to replace an existing configuration file.
+        :raises FileExistsError: If the file exists and ``overwrite`` is ``False``.
+        :return: A loaded configuration after initialization.
+        """
+
+        config_path = directory / CONFIG_FILE
+        if config_path.exists() and not overwrite:
+            raise FileExistsError(
+                f"{CONFIG_FILE} already exists. Use --overwrite to replace it."
+            )
+        config_path.write_text(json.dumps(DEFAULT_CONFIG, indent=2))
+        workspace_dir = directory / DEFAULT_CONFIG["workspace"]
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        return cls.load(directory)
+
+    def save(self) -> None:
+        """Persist the configuration to disk."""
+
+        self.path.write_text(
+            json.dumps(
+                {
+                    "profile": self.profile,
+                    "workspace": str(self.workspace),
+                    "playbooks": self.playbooks,
+                },
+                indent=2,
+            )
+        )
+
+
+def detect_termux() -> bool:
+    """Return ``True`` when running under Termux.
+
+    The check is intentionally lightweight and uses environment variables that
+    are set by Termux out of the box.
+
+    :return: ``True`` if Termux-specific environment variables are present.
+    """
+
+    return "TERMUX_VERSION" in os.environ or "com.termux" in os.environ.get(
+        "PREFIX", ""
+    )
+

--- a/terdex/engine.py
+++ b/terdex/engine.py
@@ -1,0 +1,82 @@
+"""Prompt engineering utilities for Terdex."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, Optional, Sequence
+
+TERDEX_SYSTEM_PROMPT = """
+You are Terdex, a Termux-aware planning assistant. You help developers working on
+Android devices craft concise, actionable plans that can be executed inside the
+Termux shell. Always consider:
+- Package management relies on `pkg`/`apt` rather than `sudo` or Homebrew.
+- Devices often have limited RAM and CPU resources, so prefer lightweight tools.
+- File paths should avoid hard-coded `/data/data` prefixes and assume a POSIX shell.
+- Networking may be unreliable; cache downloads when possible.
+
+When asked for help you must respond with a single JSON object using the schema:
+{
+  "task_summary": "Short description of the task in 1 sentence",
+  "steps": [
+    {
+      "title": "High-level action title",
+      "command": "Specific Termux-friendly shell command, if relevant",
+      "notes": "Optional clarifications or cautions"
+    }
+  ],
+  "environment": "One sentence reminder about Termux constraints"
+}
+
+If a shell command is not required for a step, use an empty string for the
+"command" field. Keep responses focused and avoid markdown outside the JSON.
+""".strip()
+
+
+@dataclass
+class TerdexEngine:
+    """Utility to generate structured chat prompts for Terdex."""
+
+    enable_chain_of_thought: bool = False
+
+    def build_messages(
+        self,
+        description: str,
+        *,
+        termux: Optional[bool] = None,
+        history: Optional[Sequence[Mapping[str, str]]] = None,
+    ) -> List[Mapping[str, str]]:
+        """Construct a chat message list suitable for the Ollama client."""
+
+        messages: List[Mapping[str, str]] = [{"role": "system", "content": TERDEX_SYSTEM_PROMPT}]
+        if history:
+            for message in history:
+                role = message.get("role")
+                content = message.get("content")
+                if isinstance(role, str) and isinstance(content, str):
+                    messages.append({"role": role, "content": content})
+
+        environment_hint = (
+            "The user is running inside Termux on Android."
+            if termux
+            else (
+                "The user may be on a standard Linux distribution but wants "
+                "Termux-compatible steps."
+            )
+        )
+
+        user_instructions = [
+            "Plan the work before execution and output valid JSON only.",
+            environment_hint,
+            f"Task: {description.strip()}",
+        ]
+        if self.enable_chain_of_thought:
+            user_instructions.insert(
+                1,
+                (
+                    "Think step-by-step to ensure the plan is safe, then provide only "
+                    "the JSON object in the final response."
+                ),
+            )
+
+        messages.append({"role": "user", "content": "\n".join(user_instructions)})
+        return messages

--- a/terdex/ollama_support.py
+++ b/terdex/ollama_support.py
@@ -1,0 +1,75 @@
+"""Helpers for interacting with the local Ollama runtime."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from .engine import TerdexEngine
+
+
+class OllamaUnavailableError(RuntimeError):
+    """Raised when the Ollama Python package is not available."""
+
+
+def _load_chat_callable() -> Callable[..., Any]:
+    try:
+        from ollama import chat as ollama_chat  # type: ignore import-not-found
+    except ImportError as exc:  # pragma: no cover - explicit error message
+        raise OllamaUnavailableError(
+            "The `ollama` package is required. Install it with `pip install ollama` "
+            "or `pip install .[ollama]`, and ensure the Ollama service is running."
+        ) from exc
+    return ollama_chat
+
+
+def request_plan_from_ollama(
+    description: str,
+    *,
+    model: str,
+    stream: bool = False,
+    chat_fn: Optional[Callable[..., Any]] = None,
+    termux: Optional[bool] = None,
+    chain_of_thought: bool = False,
+) -> str:
+    """Request a plan from an Ollama model and return the combined text."""
+
+    engine = TerdexEngine(enable_chain_of_thought=chain_of_thought)
+    messages = engine.build_messages(description, termux=termux)
+
+    chat = chat_fn or _load_chat_callable()
+    response = chat(model=model, messages=messages, stream=stream)
+    if stream:
+        chunks: list[str] = []
+        for part in response:  # type: ignore[not-an-iterable]
+            content = _extract_content(part)
+            if content:
+                chunks.append(content)
+        return "".join(chunks)
+    return _extract_content(response)
+
+
+def _extract_content(result: Any) -> str:
+    """Best-effort extraction of the response text from Ollama outputs."""
+
+    if isinstance(result, dict):
+        message = result.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+    message = getattr(result, "message", None)
+    if message is not None:
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            return content
+    if hasattr(result, "__getitem__"):
+        try:
+            message = result["message"]
+            content = message["content"]
+            if isinstance(content, str):
+                return content
+        except Exception:  # pragma: no cover - fall through to default handling
+            pass
+    if isinstance(result, str):
+        return result
+    return ""

--- a/terdex/planner.py
+++ b/terdex/planner.py
@@ -1,0 +1,295 @@
+"""Planning utilities and data structures for Terdex."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+from .config import detect_termux
+from .ollama_support import request_plan_from_ollama
+
+
+@dataclass
+class PlanStep:
+    """A single actionable step in a generated plan.
+
+    :param title: Short description of the action to perform.
+    :param command: Optional shell command associated with the step.
+    :param notes: Optional free-form notes clarifying the step.
+    """
+
+    title: str
+    command: Optional[str] = None
+    notes: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, str]:
+        """Return the step as a JSON-serialisable dictionary."""
+
+        data: Dict[str, str] = {"title": self.title}
+        if self.command:
+            data["command"] = self.command
+        if self.notes:
+            data["notes"] = self.notes
+        return data
+
+    def format_lines(self, index: int) -> List[str]:
+        """Format the step for console output.
+
+        :param index: One-based index used for numbering in the console.
+        :return: Lines containing a summary, command, and notes.
+        """
+
+        lines = [f" - Step {index}: {self.title}"]
+        if self.command:
+            lines.append(f"   Command: {self.command}")
+        if self.notes:
+            lines.append(f"   Notes: {self.notes}")
+        return lines
+
+
+@dataclass
+class Plan:
+    """Structured representation of an execution plan."""
+
+    summary: str
+    steps: List[PlanStep]
+    environment_note: str
+
+    def truncated(self, max_steps: Optional[int]) -> "Plan":
+        """Return a copy limited to ``max_steps`` entries."""
+
+        if max_steps is None or max_steps >= len(self.steps):
+            return Plan(self.summary, list(self.steps), self.environment_note)
+        return Plan(self.summary, self.steps[:max_steps], self.environment_note)
+
+    def is_empty(self) -> bool:
+        """Return ``True`` when no summary or steps were produced."""
+
+        return not self.steps and not self.summary.strip()
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return the plan as a JSON-serialisable structure."""
+
+        return {
+            "summary": self.summary,
+            "steps": [step.to_dict() for step in self.steps],
+            "environment": self.environment_note,
+        }
+
+    def formatted_output(self) -> List[str]:
+        """Produce a list of lines representing the plan for console display."""
+
+        lines: List[str] = []
+        for index, step in enumerate(self.steps, start=1):
+            lines.extend(step.format_lines(index))
+        if self.environment_note:
+            if lines:
+                lines.append("")
+            lines.append(self.environment_note)
+        return lines
+
+
+def generate_plan(
+    description: str,
+    max_steps: Optional[int] = None,
+    *,
+    ollama_model: Optional[str] = None,
+    stream: bool = False,
+    ollama_chat_fn: Optional[Callable[..., object]] = None,
+    chain_of_thought: bool = False,
+) -> Plan:
+    """Return an actionable plan for ``description``.
+
+    :param description: Natural language task description supplied by the user.
+    :param max_steps: Optional cap on the number of generated steps.
+    :param ollama_model: Name of the Ollama model to query when available.
+    :param stream: Whether the Ollama client should stream responses.
+    :param ollama_chat_fn: Alternative chat callable used for testing or
+        dependency injection.
+    :param chain_of_thought: Request structured reasoning from the model.
+    :raises OllamaUnavailableError: If the Ollama backend cannot be reached.
+    :return: A :class:`Plan` describing the derived steps.
+    """
+
+    normalized = description.replace("\n", " ").strip()
+    environment_is_termux = detect_termux()
+    environment_message = _environment_message(environment_is_termux)
+    if not normalized:
+        return Plan(summary="", steps=[], environment_note=environment_message)
+
+    summary = _derive_summary(normalized)
+
+    if ollama_model:
+        raw_plan = request_plan_from_ollama(
+            normalized,
+            model=ollama_model,
+            stream=stream,
+            chat_fn=ollama_chat_fn,
+            termux=environment_is_termux,
+            chain_of_thought=chain_of_thought,
+        )
+        parsed_plan = _parse_plan_json(raw_plan)
+        if parsed_plan:
+            if not parsed_plan.summary:
+                parsed_plan.summary = summary
+            if not parsed_plan.environment_note:
+                parsed_plan.environment_note = environment_message
+            plan = parsed_plan
+        else:
+            steps = _normalize_ollama_output(raw_plan)
+            if not steps:
+                steps = _fallback_steps(normalized)
+            plan = Plan(summary=summary, steps=steps, environment_note=environment_message)
+    else:
+        steps = _fallback_steps(normalized)
+        plan = Plan(summary=summary, steps=steps, environment_note=environment_message)
+
+    if max_steps:
+        plan = plan.truncated(max_steps)
+
+    if not plan.environment_note:
+        plan.environment_note = environment_message
+
+    return plan
+
+
+def _fallback_steps(normalized_description: str) -> List[PlanStep]:
+    sentences = [
+        sentence.strip()
+        for sentence in normalized_description.replace("?", ".")
+        .replace("!", ".")
+        .split(".")
+        if sentence.strip()
+    ]
+
+    plan: List[PlanStep] = []
+    for sentence in sentences:
+        title = _capitalize(sentence)
+        plan.append(PlanStep(title=title))
+    return plan
+
+
+_LISTING_PREFIX = re.compile(r"^(?:[-*•]\s*|\d+[).:-]\s*|step\s+\d+[:.-]\s*)", re.I)
+
+
+def _parse_plan_json(raw_plan: str) -> Optional[Plan]:
+    try:
+        payload = json.loads(raw_plan)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    summary_field = payload.get("task_summary")
+    summary = summary_field.strip() if isinstance(summary_field, str) else ""
+
+    environment_text = _normalize_environment_text(payload.get("environment"))
+
+    steps_field = payload.get("steps")
+    steps: List[PlanStep] = []
+    if isinstance(steps_field, list):
+        for entry in steps_field:
+            step = _parse_step_entry(entry)
+            if step:
+                steps.append(step)
+
+    if not steps and not summary and not environment_text:
+        return None
+
+    return Plan(summary=summary, steps=steps, environment_note=environment_text)
+
+
+def _normalize_ollama_output(raw_plan: str) -> List[PlanStep]:
+    lines: List[str] = []
+    for raw_line in raw_plan.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        stripped = _LISTING_PREFIX.sub("", stripped)
+        if not stripped:
+            continue
+        lines.append(stripped)
+
+    normalized: List[PlanStep] = []
+    for line in lines:
+        normalized.append(PlanStep(title=_capitalize(line)))
+    return normalized
+
+
+def _environment_message(is_termux: Optional[bool] = None) -> str:
+    if is_termux is None:
+        is_termux = detect_termux()
+    if is_termux:
+        return (
+            "Environment: Detected Termux. Prefer `pkg` for package management and avoid sudo."
+        )
+    return (
+        "Environment: Non-Termux detected. If targeting Termux, ensure commands "
+        "are `pkg` compatible."
+    )
+
+
+def _derive_summary(description: str) -> str:
+    parts = re.split(r"[.!?]", description)
+    for part in parts:
+        cleaned = part.strip()
+        if cleaned:
+            return _capitalize(cleaned)
+    return _capitalize(description[:120].strip())
+
+
+def _normalize_environment_text(value: object) -> str:
+    if isinstance(value, str):
+        candidate = value.strip()
+        if candidate:
+            return (
+                candidate
+                if candidate.lower().startswith("environment:")
+                else f"Environment: {candidate}"
+            )
+    return ""
+
+
+def _parse_step_entry(entry: object) -> Optional[PlanStep]:
+    if isinstance(entry, dict):
+        title_field = entry.get("title") or entry.get("summary") or entry.get("action")
+        command_field = entry.get("command")
+        notes_field = entry.get("notes") or entry.get("note") or entry.get("details")
+
+        title = _clean_text(title_field)
+        command = _clean_text(command_field)
+        notes = _clean_text(notes_field)
+
+        if not title and command:
+            title = command
+
+        if title:
+            return PlanStep(title=_capitalize(title), command=command, notes=notes)
+        return None
+
+    if isinstance(entry, str):
+        cleaned = _clean_text(entry)
+        if cleaned:
+            return PlanStep(title=_capitalize(cleaned))
+
+    return None
+
+
+def _clean_text(value: object) -> Optional[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    return None
+
+
+def _capitalize(text: str) -> str:
+    if not text:
+        return ""
+    text = text.strip()
+    if not text:
+        return ""
+    return text[0].upper() + text[1:]
+

--- a/terdex/playbooks.py
+++ b/terdex/playbooks.py
@@ -1,0 +1,68 @@
+"""Playbook execution helpers for Terdex."""
+
+from __future__ import annotations
+
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Iterable, List, Optional, Sequence
+
+
+def execute_playbook(
+    commands: Iterable[str],
+    *,
+    shell: bool = True,
+    parallel: bool = False,
+    max_workers: Optional[int] = None,
+) -> int:
+    """Execute the provided shell ``commands``.
+
+    The function defaults to sequential execution for backwards compatibility but
+    can process commands in parallel when ``parallel`` is ``True``. Parallel mode
+    improves throughput for independent commands such as package downloads or
+    formatting jobs.
+
+    :param commands: Commands to execute.
+    :param shell: Whether to execute through the system shell.
+    :param parallel: Enable threaded execution across commands.
+    :param max_workers: Optional limit for the thread pool size in parallel mode.
+    :return: Exit code from the execution (``0`` on success).
+    """
+
+    command_list: Sequence[str] = list(commands)
+    if not command_list:
+        return 0
+
+    if not parallel:
+        for command in command_list:
+            print(f"$ {command}")
+            completed = subprocess.run(command, shell=shell, check=False)
+            if completed.returncode != 0:
+                print(f"Command failed with exit code {completed.returncode}")
+                return completed.returncode
+        return 0
+
+    results: List[int] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(_run_command, command, shell): command
+            for command in command_list
+        }
+        for future in as_completed(futures):
+            command = futures[future]
+            return_code = future.result()
+            results.append(return_code)
+            status = "succeeded" if return_code == 0 else f"failed ({return_code})"
+            print(f"[parallel] {command} -> {status}")
+
+    for return_code in results:
+        if return_code != 0:
+            return return_code
+    return 0
+
+
+def _run_command(command: str, shell: bool) -> int:
+    completed = subprocess.run(command, shell=shell, check=False)
+    if completed.returncode != 0:
+        print(f"Command failed with exit code {completed.returncode}")
+    return completed.returncode
+

--- a/terdex/plugins/__init__.py
+++ b/terdex/plugins/__init__.py
@@ -1,0 +1,3 @@
+"""Plugin helpers for Terdex."""
+
+__all__ = ["confetti"]

--- a/terdex/plugins/confetti.py
+++ b/terdex/plugins/confetti.py
@@ -1,0 +1,64 @@
+"""Terminal confetti animation helpers."""
+
+from __future__ import annotations
+
+import random
+import shutil
+import sys
+import time
+from itertools import cycle
+from typing import Iterable
+
+try:
+    from colorama import Back, Fore, Style
+    from colorama import init as colorama_init
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Back = Fore = Style = None  # type: ignore[assignment]
+    colorama_init = None  # type: ignore[assignment]
+
+
+if Back is None or Fore is None:
+    COLORS: list[tuple[str, str]] = []
+else:
+    COLORS = [
+        (Fore.RED, Back.BLACK),
+        (Fore.GREEN, Back.BLACK),
+        (Fore.BLUE, Back.BLACK),
+        (Fore.MAGENTA, Back.BLACK),
+        (Fore.CYAN, Back.BLACK),
+        (Fore.YELLOW, Back.BLACK),
+    ]
+
+
+def celebrate_success(message: str, *, duration: float = 1.2) -> None:
+    """Render a lightweight confetti burst for ``message``.
+
+    The output includes a credit acknowledging the original idea shared by
+    ``t.me/likhonsheikh`` as requested.
+
+    :param message: Text shown beneath the confetti animation.
+    :param duration: Number of seconds to animate before resetting the style.
+    """
+
+    if Back is None or Fore is None or Style is None or not sys.stdout.isatty():
+        print(f"✨ {message} (install the 'colorama' extra for colorful confetti)")
+        print("Credit: confetti inspiration by t.me/likhonsheikh")
+        return
+
+    colorama_init(autoreset=False)  # type: ignore[misc]
+    width = shutil.get_terminal_size((80, 20)).columns
+    palette: Iterable[tuple[str, str]] = cycle(COLORS)
+    end_time = time.time() + duration
+
+    while time.time() < end_time:
+        line = [
+            f"{fore}{back}{random.choice('•·𖥸┼─')}{Style.RESET_ALL}"
+            for fore, back in [next(palette) for _ in range(width // 3)]
+        ]
+        print("".join(line))
+        time.sleep(0.05)
+
+    print(f"{Style.BRIGHT}{Fore.WHITE}{message}{Style.RESET_ALL}")
+    print("Credit: confetti inspiration by t.me/likhonsheikh")
+    sys.stdout.flush()
+

--- a/terdex/providers.py
+++ b/terdex/providers.py
@@ -1,0 +1,248 @@
+"""LLM provider helpers used by the planner."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+from .engine import TerdexEngine
+from .ollama_support import request_plan_from_ollama
+
+
+class ProviderUnavailableError(RuntimeError):
+    """Raised when an external provider cannot be reached or configured."""
+
+
+_OPENAI_COMPATIBLE_PROVIDERS = {
+    "openrouter": "https://openrouter.ai/api/v1/chat/completions",
+    "huggingface": "https://api-inference.huggingface.co/v1/chat/completions",
+}
+
+
+def request_plan_from_provider(
+    provider: str,
+    description: str,
+    *,
+    model: Optional[str],
+    termux: Optional[bool],
+    chain_of_thought: bool,
+    stream: bool,
+    options: Optional[Dict[str, str]] = None,
+    chat_fn: Optional[Callable[..., Any]] = None,
+    http_post: Optional[Callable[[str, bytes, Mapping[str, str]], str]] = None,
+) -> str:
+    """Return the raw plan text using the requested provider."""
+
+    normalized_provider = provider.lower().strip()
+    if normalized_provider in {"", "heuristic"}:
+        raise ProviderUnavailableError("The heuristic provider does not produce remote responses.")
+
+    options = options or {}
+    engine = TerdexEngine(enable_chain_of_thought=chain_of_thought)
+
+    if normalized_provider == "ollama":
+        if not model:
+            raise ProviderUnavailableError("Specify --model when using the Ollama provider.")
+        return request_plan_from_ollama(
+            description,
+            model=model,
+            stream=stream,
+            chat_fn=chat_fn,
+            termux=termux,
+            chain_of_thought=chain_of_thought,
+        )
+
+    messages = engine.build_messages(description, termux=termux)
+
+    if normalized_provider in _OPENAI_COMPATIBLE_PROVIDERS:
+        base_url = options.get("api_base") or _OPENAI_COMPATIBLE_PROVIDERS[normalized_provider]
+        api_key = _resolve_api_key(options)
+        if not api_key:
+            raise ProviderUnavailableError(
+                "An API key is required for OpenAI-compatible providers. Set --api-key "
+                "or configure llm.api_key_env."
+            )
+        if not model:
+            raise ProviderUnavailableError("Specify --model for the selected provider.")
+        payload = {"model": model, "messages": messages}
+        response = _post_json(
+            base_url,
+            payload,
+            {"Authorization": f"Bearer {api_key}"},
+            http_post=http_post,
+        )
+        return _extract_openai_content(response)
+
+    if normalized_provider == "gemini":
+        api_key = _resolve_api_key(options)
+        if not api_key:
+            raise ProviderUnavailableError(
+                "Gemini requires an API key. Configure llm.api_key_env or pass --api-key."
+            )
+        gemini_model = model or "gemini-1.5-flash"
+        base_url = options.get("api_base") or "https://generativelanguage.googleapis.com/v1beta"
+        url = f"{base_url.rstrip('/')}/models/{gemini_model}:generateContent"
+        url = f"{url}?{urllib.parse.urlencode({'key': api_key})}"
+        payload = _build_gemini_payload(messages)
+        response = _post_json(url, payload, {}, http_post=http_post)
+        return _extract_gemini_content(response)
+
+    if normalized_provider == "cohere":
+        api_key = _resolve_api_key(options)
+        if not api_key:
+            raise ProviderUnavailableError(
+                "Cohere requires an API key. Configure llm.api_key_env or pass --api-key."
+            )
+        if not model:
+            raise ProviderUnavailableError("Specify --model for the Cohere provider.")
+        base_url = options.get("api_base") or "https://api.cohere.com/v1/chat"
+        payload = _build_cohere_payload(messages, model)
+        response = _post_json(
+            base_url,
+            payload,
+            {
+                "Authorization": f"Bearer {api_key}",
+                "Cohere-Version": options.get("cohere_version", "2024-10-22"),
+            },
+            http_post=http_post,
+        )
+        return _extract_cohere_content(response)
+
+    raise ProviderUnavailableError(f"Unknown provider '{provider}'.")
+
+
+def _resolve_api_key(options: Mapping[str, str]) -> Optional[str]:
+    direct = options.get("api_key")
+    if direct:
+        return direct
+    env_name = options.get("api_key_env")
+    if env_name:
+        return os.getenv(env_name)
+    return None
+
+
+def _post_json(
+    url: str,
+    payload: Mapping[str, Any],
+    headers: Mapping[str, str],
+    *,
+    http_post: Optional[Callable[[str, bytes, Mapping[str, str]], str]] = None,
+) -> str:
+    data = json.dumps(payload).encode("utf-8")
+    merged_headers = {"Content-Type": "application/json", **headers}
+    if http_post:
+        return http_post(url, data, merged_headers)
+    request = urllib.request.Request(url, data=data, headers=merged_headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310 - intentional HTTPS call
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - depends on network
+        detail = exc.read().decode("utf-8", "ignore")
+        raise ProviderUnavailableError(f"Provider returned HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - depends on network
+        raise ProviderUnavailableError(f"Failed to reach provider endpoint: {exc.reason}") from exc
+
+
+def _extract_openai_content(raw: str) -> str:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderUnavailableError("Unable to parse provider response as JSON.") from exc
+    choices = data.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            message = choice.get("message") if isinstance(choice, dict) else None
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str):
+                    return content
+    raise ProviderUnavailableError("Provider response did not include message content.")
+
+
+def _build_gemini_payload(messages: Iterable[Mapping[str, str]]) -> Mapping[str, Any]:
+    system_prompt = ""
+    contents: List[Mapping[str, Any]] = []
+    for message in messages:
+        role = message.get("role", "user")
+        content = message.get("content", "")
+        if role == "system":
+            system_prompt = content
+            continue
+        mapped_role = "user" if role != "assistant" else "model"
+        contents.append({"role": mapped_role, "parts": [{"text": content}]})
+    payload: Dict[str, Any] = {"contents": contents}
+    if system_prompt:
+        payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
+    return payload
+
+
+def _extract_gemini_content(raw: str) -> str:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderUnavailableError("Unable to parse Gemini response.") from exc
+    candidates = data.get("candidates")
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            content = candidate.get("content") if isinstance(candidate, dict) else None
+            if isinstance(content, dict):
+                parts = content.get("parts")
+                if isinstance(parts, list):
+                    for part in parts:
+                        text = part.get("text") if isinstance(part, dict) else None
+                        if isinstance(text, str):
+                            return text
+    raise ProviderUnavailableError("Gemini response did not include text content.")
+
+
+def _build_cohere_payload(
+    messages: Iterable[Mapping[str, str]],
+    model: str,
+) -> Mapping[str, Any]:
+    system_prompt = ""
+    chat_history: List[Mapping[str, str]] = []
+    user_message = ""
+
+    for message in messages:
+        role = message.get("role", "user")
+        content = message.get("content", "")
+        if role == "system":
+            system_prompt = content
+            continue
+        if role == "user":
+            if user_message:
+                chat_history.append({"role": "USER", "message": user_message})
+            user_message = content
+        elif role == "assistant":
+            chat_history.append({"role": "CHATBOT", "message": content})
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "message": user_message,
+        "chat_history": chat_history,
+    }
+    if system_prompt:
+        payload["preamble"] = system_prompt
+    return payload
+
+
+def _extract_cohere_content(raw: str) -> str:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderUnavailableError("Unable to parse Cohere response.") from exc
+    text = data.get("text")
+    if isinstance(text, str):
+        return text
+    generations = data.get("generations")
+    if isinstance(generations, list):
+        for generation in generations:
+            gen_text = generation.get("text") if isinstance(generation, dict) else None
+            if isinstance(gen_text, str):
+                return gen_text
+    raise ProviderUnavailableError("Cohere response did not include text content.")
+

--- a/terdex/termux_reference.py
+++ b/terdex/termux_reference.py
@@ -172,6 +172,65 @@ TERMUX_REFERENCE: List[TermuxSection] = [
             ]
         ),
     ),
+    TermuxSection(
+        key="desktop",
+        title="Desktop Environments",
+        summary=(
+            "Install XFCE, LXQt, MATE, or Openbox within Termux and launch them through a VNC session for a full graphical desktop."
+        ),
+        entries=_entries(
+            [
+                (
+                    "XFCE",
+                    "pkg install xfce4, then set ~/.vnc/xstartup to run 'xfce4-session &' before starting the VNC server.",
+                ),
+                (
+                    "LXQt",
+                    "pkg install lxqt and use a minimal ~/.vnc/xstartup containing 'startlxqt &' to launch the session.",
+                ),
+                (
+                    "MATE",
+                    "Install the mate-* meta packages plus marco, then start VNC sessions with 'mate-session &' in ~/.vnc/xstartup.",
+                ),
+                (
+                    "Recommended apps",
+                    "Add lightweight browsers (netsurf or otter-browser) and terminals (xfce4-terminal, qterminal, mate-terminal) for each desktop.",
+                ),
+                (
+                    "Openbox",
+                    "Keep ~/.vnc/xstartup limited to the openbox-session launch and customise ${PREFIX}/etc/xdg/openbox/autostart for panels like PyPanel.",
+                ),
+            ]
+        ),
+    ),
+    TermuxSection(
+        key="x11",
+        title="Termux X11 Packages",
+        summary=(
+            "Enable the x11-repo, use a VNC server for display output, and explore desktop packages or build scripts maintained by the community."
+        ),
+        entries=_entries(
+            [
+                ("Enable repository", "Run pkg install x11-repo to add the official X11 packages."),
+                (
+                    "VNC setup",
+                    "Install tigervnc, start the server locally, and connect with a VNC viewer to render graphical apps.",
+                ),
+                (
+                    "Xstartup basics",
+                    "Keep ~/.vnc/xstartup minimal—usually just the desktop session command—to avoid conflicts.",
+                ),
+                (
+                    "Build locally",
+                    "Clone https://github.com/termux/x11-packages and use ./start-builder.sh then ./build-package.sh -a <arch> <package> to compile extras.",
+                ),
+                (
+                    "Hardware notes",
+                    "Hardware acceleration is generally unavailable by default when running X11 via VNC inside Termux.",
+                ),
+            ]
+        ),
+    ),
 ]
 
 

--- a/terdex/termux_reference.py
+++ b/terdex/termux_reference.py
@@ -1,0 +1,184 @@
+"""Curated Termux reference data for CLI and docs output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class TermuxEntry:
+    """Single fact or tip describing a Termux behaviour."""
+
+    name: str
+    description: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"name": self.name, "description": self.description}
+
+
+@dataclass(frozen=True)
+class TermuxSection:
+    """Collection of related Termux information items."""
+
+    key: str
+    title: str
+    summary: str
+    entries: List[TermuxEntry]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "summary": self.summary,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+
+def _entries(pairs: Iterable[tuple[str, str]]) -> List[TermuxEntry]:
+    return [TermuxEntry(name=name, description=description) for name, description in pairs]
+
+
+TERMUX_REFERENCE: List[TermuxSection] = [
+    TermuxSection(
+        key="keyboard",
+        title="Keyboard Shortcuts",
+        summary=(
+            "Volume down acts as Ctrl and Volume up acts as modifier keys so you can "
+            "access traditional terminal shortcuts from touch devices."
+        ),
+        entries=_entries(
+            [
+                ("Ctrl+A", "Move to line start."),
+                ("Ctrl+E", "Move to line end."),
+                ("Ctrl+K", "Delete from cursor to end of line."),
+                ("Ctrl+U", "Delete from cursor to start of line."),
+                ("Ctrl+L", "Clear the current terminal view."),
+                ("Ctrl+C", "Send SIGINT to stop the running process."),
+                ("Ctrl+Z", "Suspend the active process."),
+                ("Ctrl+D", "Log out or send EOF when input is empty."),
+                ("Volume Up+E", "Send Escape when hardware key is unavailable."),
+                ("Volume Up+T", "Send Tab for autocompletion."),
+                (
+                    "Volume Up+1…0",
+                    "Access function keys F1–F10 for ncurses applications.",
+                ),
+                ("Volume Up+A/D/W/S", "Arrow key navigation left/right/up/down."),
+            ]
+        ),
+    ),
+    TermuxSection(
+        key="extra-keys",
+        title="Extra Keys Configuration",
+        summary=(
+            "Customise the extra keys row via ~/.termux/termux.properties and reload with "
+            "`termux-reload-settings`."
+        ),
+        entries=_entries(
+            [
+                (
+                    "extra-keys",
+                    "Define custom rows, e.g. [['ESC','/','-','HOME','UP','END','PGUP'], …].",
+                ),
+                (
+                    "extra-keys-style",
+                    "Pick presets such as 'default', 'arrows-only', or 'all'.",
+                ),
+                (
+                    "Popup macros",
+                    "Use {key: ESC, popup: {macro: 'CTRL d', display: 'exit'}} to define swipe actions.",
+                ),
+                (
+                    "termux-reload-settings",
+                    "Apply configuration changes without restarting the app.",
+                ),
+            ]
+        ),
+    ),
+    TermuxSection(
+        key="package-management",
+        title="Package Management",
+        summary=(
+            "Use `pkg` as the wrapper around apt to install, upgrade, and remove software "
+            "within Termux without sudo."
+        ),
+        entries=_entries(
+            [
+                ("pkg install <pkg>", "Install a package after refreshing indexes."),
+                ("pkg upgrade", "Update all installed packages; run regularly."),
+                ("pkg uninstall <pkg>", "Remove a package while leaving config files."),
+                ("pkg autoclean", "Delete outdated .deb files from cache."),
+                ("pkg clean", "Clear all cached packages to free space."),
+                (
+                    "pkg list-all",
+                    "List everything available across the enabled repositories.",
+                ),
+                (
+                    "pkg search <query>",
+                    "Search repositories for packages matching the query.",
+                ),
+                (
+                    "Repository add-ons",
+                    "Install *-repo packages (e.g. science-repo) for extra package sets.",
+                ),
+            ]
+        ),
+    ),
+    TermuxSection(
+        key="termux-api",
+        title="Termux API",
+        summary=(
+            "Install the termux-api package plus the Android add-on to access device hardware "
+            "from scripts (battery, sensors, clipboard, notifications, etc.)."
+        ),
+        entries=_entries(
+            [
+                ("termux-battery-status", "Print current battery state."),
+                ("termux-clipboard-get/set", "Read or write clipboard text."),
+                ("termux-notification", "Show custom Android notifications."),
+                ("termux-toast", "Display a transient toast message."),
+                ("termux-camera-photo", "Capture a photo to a specified path."),
+                ("termux-location", "Fetch current location coordinates."),
+                ("termux-media-player", "Play audio or video files."),
+            ]
+        ),
+    ),
+    TermuxSection(
+        key="appearance",
+        title="Appearance and Sessions",
+        summary=(
+            "Tweak UI behaviour through ~/.termux/termux.properties, including dark mode, fullscreen, and session shortcuts."
+        ),
+        entries=_entries(
+            [
+                ("use-black-ui", "Force dark UI elements in drawers and dialogs."),
+                ("fullscreen", "Enable fullscreen terminal rendering."),
+                (
+                    "shortcut.create-session",
+                    "Map Ctrl+T to open a new terminal session.",
+                ),
+                (
+                    "shortcut.next-session/previous-session",
+                    "Navigate between sessions with custom key combos.",
+                ),
+                (
+                    "enforce-char-based-input",
+                    "Work around keyboards that enforce word-based input.",
+                ),
+                (
+                    "terminal-margin-horizontal",
+                    "Adjust left/right padding (0–100 dp).",
+                ),
+            ]
+        ),
+    ),
+]
+
+
+def lookup_section(key: str) -> TermuxSection | None:
+    key_lower = key.lower()
+    for section in TERMUX_REFERENCE:
+        if section.key == key_lower:
+            return section
+    return None
+

--- a/terdex/termux_reference.py
+++ b/terdex/termux_reference.py
@@ -86,7 +86,8 @@ TERMUX_REFERENCE: List[TermuxSection] = [
                 ),
                 (
                     "Popup macros",
-                    "Use {key: ESC, popup: {macro: 'CTRL d', display: 'exit'}} to define swipe actions.",
+                    "Use {key: ESC, popup: {macro: 'CTRL d', display: 'exit'}} "
+                    "to define swipe actions.",
                 ),
                 (
                     "termux-reload-settings",
@@ -147,7 +148,8 @@ TERMUX_REFERENCE: List[TermuxSection] = [
         key="appearance",
         title="Appearance and Sessions",
         summary=(
-            "Tweak UI behaviour through ~/.termux/termux.properties, including dark mode, fullscreen, and session shortcuts."
+            "Tweak UI behaviour through ~/.termux/termux.properties, including dark mode, "
+            "fullscreen, and session shortcuts."
         ),
         entries=_entries(
             [
@@ -176,29 +178,35 @@ TERMUX_REFERENCE: List[TermuxSection] = [
         key="desktop",
         title="Desktop Environments",
         summary=(
-            "Install XFCE, LXQt, MATE, or Openbox within Termux and launch them through a VNC session for a full graphical desktop."
+            "Install XFCE, LXQt, MATE, or Openbox within Termux and launch them through a "
+            "VNC session for a full graphical desktop."
         ),
         entries=_entries(
             [
                 (
                     "XFCE",
-                    "pkg install xfce4, then set ~/.vnc/xstartup to run 'xfce4-session &' before starting the VNC server.",
+                    "pkg install xfce4, then set ~/.vnc/xstartup to run 'xfce4-session &' "
+                    "before starting the VNC server.",
                 ),
                 (
                     "LXQt",
-                    "pkg install lxqt and use a minimal ~/.vnc/xstartup containing 'startlxqt &' to launch the session.",
+                    "pkg install lxqt and use a minimal ~/.vnc/xstartup containing "
+                    "'startlxqt &' to launch the session.",
                 ),
                 (
                     "MATE",
-                    "Install the mate-* meta packages plus marco, then start VNC sessions with 'mate-session &' in ~/.vnc/xstartup.",
+                    "Install the mate-* meta packages plus marco, then start VNC sessions "
+                    "with 'mate-session &' in ~/.vnc/xstartup.",
                 ),
                 (
                     "Recommended apps",
-                    "Add lightweight browsers (netsurf or otter-browser) and terminals (xfce4-terminal, qterminal, mate-terminal) for each desktop.",
+                    "Add lightweight browsers (netsurf or otter-browser) and terminals "
+                    "(xfce4-terminal, qterminal, mate-terminal) for each desktop.",
                 ),
                 (
                     "Openbox",
-                    "Keep ~/.vnc/xstartup limited to the openbox-session launch and customise ${PREFIX}/etc/xdg/openbox/autostart for panels like PyPanel.",
+                    "Keep ~/.vnc/xstartup limited to the openbox-session launch and "
+                    "customise ${PREFIX}/etc/xdg/openbox/autostart for panels like PyPanel.",
                 ),
             ]
         ),
@@ -207,26 +215,31 @@ TERMUX_REFERENCE: List[TermuxSection] = [
         key="x11",
         title="Termux X11 Packages",
         summary=(
-            "Enable the x11-repo, use a VNC server for display output, and explore desktop packages or build scripts maintained by the community."
+            "Enable the x11-repo, use a VNC server for display output, and explore desktop "
+            "packages or build scripts maintained by the community."
         ),
         entries=_entries(
             [
                 ("Enable repository", "Run pkg install x11-repo to add the official X11 packages."),
                 (
                     "VNC setup",
-                    "Install tigervnc, start the server locally, and connect with a VNC viewer to render graphical apps.",
+                    "Install tigervnc, start the server locally, and connect with a VNC "
+                    "viewer to render graphical apps.",
                 ),
                 (
                     "Xstartup basics",
-                    "Keep ~/.vnc/xstartup minimal—usually just the desktop session command—to avoid conflicts.",
+                    "Keep ~/.vnc/xstartup minimal—usually just the desktop session "
+                    "command—to avoid conflicts.",
                 ),
                 (
                     "Build locally",
-                    "Clone https://github.com/termux/x11-packages and use ./start-builder.sh then ./build-package.sh -a <arch> <package> to compile extras.",
+                    "Clone https://github.com/termux/x11-packages and use ./start-builder.sh "
+                    "then ./build-package.sh -a <arch> <package> to compile extras.",
                 ),
                 (
                     "Hardware notes",
-                    "Hardware acceleration is generally unavailable by default when running X11 via VNC inside Termux.",
+                    "Hardware acceleration is generally unavailable by default when running "
+                    "X11 via VNC inside Termux.",
                 ),
             ]
         ),

--- a/tests/test_cli_prompts.py
+++ b/tests/test_cli_prompts.py
@@ -1,0 +1,23 @@
+import json
+from types import SimpleNamespace
+
+from terdex.cli import CHAIN_OF_THOUGHT_PROMPTS, command_prompts
+
+
+def test_prompts_json_output(capsys):
+    args = SimpleNamespace(json=True)
+    assert command_prompts(args) == 0
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert payload["title"].startswith("Chain-of-thought prompts")
+    assert payload["prompts"] == CHAIN_OF_THOUGHT_PROMPTS
+
+
+def test_prompts_text_output(capsys):
+    args = SimpleNamespace(json=False)
+    assert command_prompts(args) == 0
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured[0].startswith("Chain-of-thought prompt ideas")
+    numbered = [line for line in captured if line and line[0].isdigit()]
+    assert len(numbered) == len(CHAIN_OF_THOUGHT_PROMPTS)
+    assert numbered[0].startswith("1. ")

--- a/tests/test_cli_termux.py
+++ b/tests/test_cli_termux.py
@@ -1,0 +1,32 @@
+import json
+from types import SimpleNamespace
+
+from terdex.cli import command_termux
+from terdex.termux_reference import TERMUX_REFERENCE
+
+
+def test_termux_command_text_output(capsys):
+    args = SimpleNamespace(section=None, json=False)
+    assert command_termux(args) == 0
+    captured = capsys.readouterr().out
+    first_section = TERMUX_REFERENCE[0]
+    assert first_section.title in captured
+    for entry in first_section.entries[:2]:
+        assert entry.name in captured
+
+
+def test_termux_command_json_output(capsys):
+    section = TERMUX_REFERENCE[1]
+    args = SimpleNamespace(section=section.key, json=True)
+    assert command_termux(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["title"] == "Termux quick reference"
+    assert len(payload["sections"]) == 1
+    assert payload["sections"][0]["key"] == section.key
+
+
+def test_termux_command_unknown_section(capsys):
+    args = SimpleNamespace(section="unknown", json=False)
+    assert command_termux(args) == 1
+    captured = capsys.readouterr().out
+    assert "Unknown section" in captured

--- a/tests/test_cli_termux.py
+++ b/tests/test_cli_termux.py
@@ -30,3 +30,11 @@ def test_termux_command_unknown_section(capsys):
     assert command_termux(args) == 1
     captured = capsys.readouterr().out
     assert "Unknown section" in captured
+
+
+def test_termux_command_desktop_section(capsys):
+    args = SimpleNamespace(section="desktop", json=False)
+    assert command_termux(args) == 0
+    captured = capsys.readouterr().out
+    assert "Desktop Environments" in captured
+    assert "xfce4-session" in captured

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,18 @@
+from terdex.engine import TERDEX_SYSTEM_PROMPT, TerdexEngine
+
+
+def test_engine_build_messages_includes_context():
+    engine = TerdexEngine()
+    messages = engine.build_messages("set up git", termux=True)
+    assert messages[0]["content"] == TERDEX_SYSTEM_PROMPT
+    assert "Termux" in messages[0]["content"]
+    assert messages[-1]["role"] == "user"
+    assert "set up git" in messages[-1]["content"]
+    assert "Termux" in messages[-1]["content"]
+
+
+def test_engine_chain_of_thought_instruction():
+    engine = TerdexEngine(enable_chain_of_thought=True)
+    messages = engine.build_messages("install python", termux=False)
+    user_content = messages[-1]["content"]
+    assert "Think step-by-step" in user_content

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from terdex.config import AppConfig
+from terdex.ollama_support import OllamaUnavailableError
+from terdex.planner import Plan, PlanStep, generate_plan
+
+
+def test_generate_plan_basic():
+    description = "create api endpoint. add tests. update docs."
+    plan = generate_plan(description)
+    assert isinstance(plan, Plan)
+    assert plan.steps[0].title.startswith("Create api endpoint")
+    assert plan.environment_note.startswith("Environment:")
+
+
+def test_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    config_dir = tmp_path
+    config = AppConfig.initialize(config_dir)
+    config.profile = "termux"
+    config.playbooks["custom"] = ["echo hello"]
+    config.save()
+
+    loaded = AppConfig.load(config_dir)
+    assert loaded.profile == "termux"
+    assert loaded.playbooks["custom"] == ["echo hello"]
+
+
+def test_detect_termux(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TERMUX_VERSION", "0.118")
+    plan = generate_plan("simple step")
+    assert plan.environment_note.startswith("Environment: Detected Termux")
+
+    monkeypatch.delenv("TERMUX_VERSION")
+    plan = generate_plan("simple step")
+    assert "Non-Termux" in plan.environment_note
+
+
+def test_generate_plan_with_stubbed_ollama():
+    def fake_chat(*, model, messages, stream):
+        assert model == "stub-model"
+        assert not stream
+        assert "do the thing" in messages[-1]["content"]
+        return SimpleNamespace(message=SimpleNamespace(content="1. gather tools\n2. run build"))
+
+    plan = generate_plan(
+        "do the thing",
+        ollama_model="stub-model",
+        ollama_chat_fn=fake_chat,
+    )
+
+    assert [step.title for step in plan.steps] == ["Gather tools", "Run build"]
+    assert plan.environment_note.startswith("Environment:")
+
+
+def test_generate_plan_ollama_missing():
+    with pytest.raises(OllamaUnavailableError):
+        generate_plan("do things", ollama_model="gemma3")
+
+
+def test_generate_plan_with_json_payload():
+    payload = {
+        "task_summary": "Install dependencies",
+        "steps": [
+            {
+                "title": "Update package lists",
+                "command": "pkg update -y",
+                "notes": "Ensure repositories are reachable",
+            },
+            {
+                "title": "Install git",
+                "command": "pkg install -y git",
+                "notes": "",
+            },
+        ],
+        "environment": "Environment: Termux detected"
+    }
+
+    def fake_chat(*, model, messages, stream):
+        assert model == "json-model"
+        assert not stream
+        assert messages[-1]["role"] == "user"
+        return SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))
+
+    plan = generate_plan(
+        "install git",
+        ollama_model="json-model",
+        ollama_chat_fn=fake_chat,
+    )
+
+    assert plan.summary == "Install dependencies"
+    assert plan.steps[0] == PlanStep(
+        title="Update package lists",
+        command="pkg update -y",
+        notes="Ensure repositories are reachable",
+    )
+    assert plan.steps[1].title == "Install git"
+    assert plan.environment_note == "Environment: Termux detected"

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -4,9 +4,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from terdex.config import AppConfig
+from terdex.config import AppConfig, LLMSettings
 from terdex.ollama_support import OllamaUnavailableError
 from terdex.planner import Plan, PlanStep, generate_plan
+from terdex.providers import ProviderUnavailableError
 
 
 def test_generate_plan_basic():
@@ -22,11 +23,23 @@ def test_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     config = AppConfig.initialize(config_dir)
     config.profile = "termux"
     config.playbooks["custom"] = ["echo hello"]
+    config.llm = LLMSettings(
+        provider="openrouter",
+        model="meta-llama",
+        api_base="https://example.com",
+        api_key_env="OPENROUTER_KEY",
+        options={"routing": "priority"},
+    )
     config.save()
 
     loaded = AppConfig.load(config_dir)
     assert loaded.profile == "termux"
     assert loaded.playbooks["custom"] == ["echo hello"]
+    assert loaded.llm.provider == "openrouter"
+    assert loaded.llm.model == "meta-llama"
+    assert loaded.llm.api_base == "https://example.com"
+    assert loaded.llm.api_key_env == "OPENROUTER_KEY"
+    assert loaded.llm.options == {"routing": "priority"}
 
 
 def test_detect_termux(monkeypatch: pytest.MonkeyPatch):
@@ -59,6 +72,51 @@ def test_generate_plan_with_stubbed_ollama():
 def test_generate_plan_ollama_missing():
     with pytest.raises(OllamaUnavailableError):
         generate_plan("do things", ollama_model="gemma3")
+
+
+def test_generate_plan_openrouter_with_stub_http():
+    captured = {}
+
+    def fake_http(url: str, data: bytes, headers):
+        captured["url"] = url
+        captured["payload"] = json.loads(data.decode("utf-8"))
+        captured["headers"] = headers
+        return json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "1. gather data\n2. summarise results",
+                        }
+                    }
+                ]
+            }
+        )
+
+    plan = generate_plan(
+        "gather data",
+        provider="openrouter",
+        model="meta/llama",
+        provider_options={"api_key": "stub"},
+        http_post=fake_http,
+    )
+
+    assert plan.steps[0].title == "Gather data"
+    assert plan.steps[1].title == "Summarise results"
+    assert captured["url"].startswith("https://openrouter.ai")
+    assert captured["payload"]["model"] == "meta/llama"
+    assert captured["headers"]["Authorization"] == "Bearer stub"
+
+
+def test_generate_plan_openrouter_missing_key():
+    with pytest.raises(ProviderUnavailableError):
+        generate_plan(
+            "analyse code",
+            provider="openrouter",
+            model="meta/llama",
+            provider_options={},
+            http_post=lambda *_: "{}",
+        )
 
 
 def test_generate_plan_with_json_payload():


### PR DESCRIPTION
## Summary
- add a `terdex termux` command with JSON output and section filtering for curated shortcuts and configuration tips
- introduce a shared Termux reference dataset and publish it as docs/TERMUX_GUIDE.md for offline browsing
- cover the new command with unit tests and refresh the README to highlight the reference options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d657be5048832e9273f84d51a99cbc